### PR TITLE
Fix typo for provider.tf example

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     rootly = {
-      source = "rootly/rootly"
+      source = "rootlyhq/rootly"
     }
   }
 }


### PR DESCRIPTION
The namespace has to be the GitHub org name.