### PR TITLE
Address provider typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     rootly = {
-      source = "rootly/rootly"
+      source = "rootlyhq/rootly"
     }
   }
 }


### PR DESCRIPTION
This was omitted in the previous PR, and does not reflect on the website (since I didn't generated the docs post-change)