### PR TITLE
[BUG] Remove diff supress since its not applying content changes

### DIFF
--- a/provider/resource_post_mortem_template.go
+++ b/provider/resource_post_mortem_template.go
@@ -45,9 +45,6 @@ func resourcePostmortemTemplate() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 				Description: "The postmortem template. Liquid syntax and markdown are supported.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true // suppress diffing for this field, since it will always be different than what is specified in configuration, as input is sanitized and formatted on the server.
-				},
 			},
 		},
 	}


### PR DESCRIPTION
PostmortemTemplate content isn't applied for any changes.

Slack: https://rootly-workspace.slack.com/archives/C03MTKD3GKS/p1673345627492829

API call with content works fine. 