### PR TITLE
Fix workflow_task_publish_incident example

### DIFF
--- a/docs/resources/workflow_task_publish_incident.md
+++ b/docs/resources/workflow_task_publish_incident.md
@@ -27,8 +27,8 @@ resource "rootly_workflow_task_publish_incident" "publish_incident" {
   workflow_id     = rootly_workflow_incident.auto_publish_incident_resolved_to_status_page.id
   skip_on_failure = false
   enabled         = true
+  name            = "Publish incident resolved to status page"
   task_params {
-    name = "Publish incident resolved to status page"
     incident = {
       id   = "{{ incident.id }}"
       name = "{{ incident.id }}"


### PR DESCRIPTION
`name` is expected outside of `task_params`