### PR TITLE
[ROOT-1030] Remove immutable fields from docs and payload, and add deprecation warning to Resource.

### DIFF
--- a/client/roles.go
+++ b/client/roles.go
@@ -13,8 +13,6 @@ type Role struct {
 	Name string `jsonapi:"attr,name,omitempty"`
   Slug string `jsonapi:"attr,slug,omitempty"`
   IncidentPermissionSetId string `jsonapi:"attr,incident_permission_set_id,omitempty"`
-  IsDeletable *bool `jsonapi:"attr,is_deletable,omitempty"`
-  IsEditable *bool `jsonapi:"attr,is_editable,omitempty"`
   AlertsPermissions []interface{} `jsonapi:"attr,alerts_permissions,omitempty"`
   PulsesPermissions []interface{} `jsonapi:"attr,pulses_permissions,omitempty"`
   ApiKeysPermissions []interface{} `jsonapi:"attr,api_keys_permissions,omitempty"`

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -35,8 +35,6 @@ description: |-
 - `incident_types_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `incidents_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `invitations_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
-- `is_deletable` (Boolean) Whether the role can be deleted.. Value must be one of true or false
-- `is_editable` (Boolean) Whether the role can be edited.. Value must be one of true or false
 - `playbooks_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `private_incidents_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `pulses_permissions` (List of String) Value must be one of `create`, `update`, `read`.

--- a/provider/resource_role.go
+++ b/provider/resource_role.go
@@ -55,6 +55,7 @@ func resourceRole() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Whether the role can be deleted.. Value must be one of true or false",
+				Deprecated:  "This resource is now ignored by the API, and will be removed in the next release.",
 			},
 
 			"is_editable": &schema.Schema{
@@ -63,6 +64,7 @@ func resourceRole() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Whether the role can be edited.. Value must be one of true or false",
+				Deprecated:  "This resource is now ignored by the API, and will be removed in the next release.",
 			},
 
 			"alerts_permissions": &schema.Schema{
@@ -384,12 +386,6 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	if value, ok := d.GetOkExists("incident_permission_set_id"); ok {
 		s.IncidentPermissionSetId = value.(string)
 	}
-	if value, ok := d.GetOkExists("is_deletable"); ok {
-		s.IsDeletable = tools.Bool(value.(bool))
-	}
-	if value, ok := d.GetOkExists("is_editable"); ok {
-		s.IsEditable = tools.Bool(value.(bool))
-	}
 	if value, ok := d.GetOkExists("alerts_permissions"); ok {
 		s.AlertsPermissions = value.([]interface{})
 	}
@@ -497,8 +493,6 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("incident_permission_set_id", item.IncidentPermissionSetId)
-	d.Set("is_deletable", item.IsDeletable)
-	d.Set("is_editable", item.IsEditable)
 	d.Set("alerts_permissions", item.AlertsPermissions)
 	d.Set("pulses_permissions", item.PulsesPermissions)
 	d.Set("api_keys_permissions", item.ApiKeysPermissions)
@@ -542,12 +536,6 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	if d.HasChange("incident_permission_set_id") {
 		s.IncidentPermissionSetId = d.Get("incident_permission_set_id").(string)
-	}
-	if d.HasChange("is_deletable") {
-		s.IsDeletable = tools.Bool(d.Get("is_deletable").(bool))
-	}
-	if d.HasChange("is_editable") {
-		s.IsEditable = tools.Bool(d.Get("is_editable").(bool))
 	}
 	if d.HasChange("alerts_permissions") {
 		s.AlertsPermissions = d.Get("alerts_permissions").([]interface{})


### PR DESCRIPTION
The API ignores `is_deletable` and `is_editable` settings from incoming payloads.

See: https://github.com/rootlyhq/rootly/blob/development/app/controllers/api/v1/roles_controller.rb#L54-L88

Note the absence of these two fields. 😁 

This deprecates them instead of removing them outright, to avoid breaking existing TF configurations.

~It looks like the `TestAccResourceCustomFieldOption` suite is failing, due to something unhappy over on the Rootly API side. Not sure which API key this uses, so I'd kind of be flying blind.~

Nevermind. Flaky test is flaky. Not exclusive to our Rails app. 😁 