### PR TITLE
docs(schedule): Adding Import statement for schedules

### DIFF
--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -185,3 +185,20 @@ resource "rootly_escalation_level" "second" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+### Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Schedules using the `id`. For example:
+
+```terraform
+import {
+  to rootly_schedule.primary
+  id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+Using `terraform import`, import Schedules using the `id`. For example:
+
+```console
+% terraform import rootly_schedule.primary 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
Whilst working with a trial plan i found that the import statements were missing on schedules(Possibly more).

this change seeks to introduce only a documentation change to demonstrate how to do such import. 