### PR TITLE
fix: send correct default value for schedule.slack_user_group

### DIFF
--- a/client/schedules.go
+++ b/client/schedules.go
@@ -16,7 +16,7 @@ type Schedule struct {
 	Name            string                 `jsonapi:"attr,name,omitempty"`
 	Description     string                 `jsonapi:"attr,description,omitempty"`
 	AllTimeCoverage *bool                  `jsonapi:"attr,all_time_coverage,omitempty"`
-	SlackUserGroup  map[string]interface{} `jsonapi:"attr,slack_user_group,omitempty"`
+	SlackUserGroup  map[string]interface{} `jsonapi:"attr,slack_user_group"`
 	OwnerGroupIds   []interface{}          `jsonapi:"attr,owner_group_ids,omitempty"`
 	OwnerUserId     int                    `jsonapi:"attr,owner_user_id,omitempty"`
 }

--- a/provider/resource_schedule.go
+++ b/provider/resource_schedule.go
@@ -82,8 +82,7 @@ func resourceSchedule() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Computed:    true,
-				Required:    false,
+				Default:  map[string]interface{}{},
 				Optional:    true,
 				Description: "Map must contain two fields, `id` and `name`. Synced slack group of the schedule",
 			},
@@ -129,7 +128,14 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta in
 		s.AllTimeCoverage = tools.Bool(value.(bool))
 	}
 	if value, ok := d.GetOkExists("slack_user_group"); ok {
-		s.SlackUserGroup = value.(map[string]interface{})
+		slackUserGroup := value.(map[string]interface{})
+		if len(slackUserGroup) == 0 {
+			s.SlackUserGroup = map[string]interface{}{}
+		} else {
+			s.SlackUserGroup = slackUserGroup
+		}
+	} else {
+		s.SlackUserGroup = map[string]interface{}{}
 	}
 	if value, ok := d.GetOkExists("owner_group_ids"); ok {
 		s.OwnerGroupIds = value.([]interface{})
@@ -192,7 +198,16 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		s.AllTimeCoverage = tools.Bool(d.Get("all_time_coverage").(bool))
 	}
 	if d.HasChange("slack_user_group") {
-		s.SlackUserGroup = d.Get("slack_user_group").(map[string]interface{})
+		if value := d.Get("slack_user_group"); value != nil {
+			slackUserGroup := value.(map[string]interface{})
+			if len(slackUserGroup) == 0 {
+				s.SlackUserGroup = map[string]interface{}{}
+			} else {
+				s.SlackUserGroup = slackUserGroup
+			}
+		} else {
+			s.SlackUserGroup = map[string]interface{}{}
+		}
 	}
 	if d.HasChange("owner_group_ids") {
 		s.OwnerGroupIds = d.Get("owner_group_ids").([]interface{})

--- a/provider/resource_schedule_test.go
+++ b/provider/resource_schedule_test.go
@@ -17,12 +17,15 @@ func TestAccResourceSchedule(t *testing.T) {
 				Config: testAccResourceScheduleCreated,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("rootly_schedule.tf", "name", "test-initial"),
+					resource.TestCheckResourceAttr("rootly_schedule.tf", "slack_user_group.id", "123XYZ"),
+					resource.TestCheckResourceAttr("rootly_schedule.tf", "slack_user_group.name", "test"),
 					resource.TestCheckResourceAttr("rootly_schedule_rotation.tf", "name", "test-initial"),
 				),
 			},
 			{
 				Config: testAccResourceScheduleUpdated,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("rootly_schedule.tf", "slack_user_group.id"),
 					resource.TestCheckResourceAttr("rootly_schedule.tf", "name", "test-updated"),
 					resource.TestCheckResourceAttr("rootly_schedule_rotation.tf", "name", "test-updated"),
 				),
@@ -34,6 +37,10 @@ func TestAccResourceSchedule(t *testing.T) {
 const testAccResourceScheduleCreated = `
 resource "rootly_schedule" "tf" {
 	name = "test-initial"
+	slack_user_group = {
+		id = "123XYZ"
+		name = "test"
+	}
 }
 resource "rootly_schedule_rotation" "tf" {
 	schedule_id     = rootly_schedule.tf.id


### PR DESCRIPTION
The API crashes on null. Sending an empty object avoids this.

Resolves #105