### PR TITLE
[OC-1811] Fix Schedule Rotation Resource Documentation Discrepancies

### DIFF
--- a/docs/resources/schedule_rotation.md
+++ b/docs/resources/schedule_rotation.md
@@ -173,6 +173,7 @@ resource "rootly_escalation_level" "second" {
 ### Required
 
 - `name` (String) The name of the schedule rotation
+- `schedule_id` (String) The ID of parent schedule
 - `schedule_rotationable_attributes` (Map of String) handoff_time and/or handoff_day may be required, depending on schedule_rotationable_type. Please see API docs for options based on schedule_rotationable_type: https://docs.rootly.com/api-reference/schedulerotations/creates-a-schedule-rotation#response-data-attributes-schedule-rotationable-attributes
 
 ### Optional
@@ -180,10 +181,9 @@ resource "rootly_escalation_level" "second" {
 - `active_all_week` (Boolean) Schedule rotation active all week?. Value must be one of true or false
 - `active_days` (List of String) Value must be one of `S`, `M`, `T`, `W`, `R`, `F`, `U`.
 - `active_time_attributes` (Block List) Schedule rotation's active times (see [below for nested schema](#nestedblock--active_time_attributes))
-- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`.
+- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any rootly_schedule_rotation_active_day resources linked to this schedule rotation.
 - `end_time` (String) ISO8601 date and time when rotation ends. Shifts will only be created before this time.
 - `position` (Number) Position of the schedule rotation
-- `schedule_id` (String) The ID of parent schedule
 - `schedule_rotationable_type` (String) Schedule rotation type. Value must be one of `ScheduleDailyRotation`, `ScheduleWeeklyRotation`, `ScheduleBiweeklyRotation`, `ScheduleMonthlyRotation`, `ScheduleCustomRotation`.
 - `start_time` (String) ISO8601 date and time when rotation starts. Shifts will only be created after this time.
 - `time_zone` (String) A valid IANA time zone name.

--- a/docs/resources/schedule_rotation.md
+++ b/docs/resources/schedule_rotation.md
@@ -181,7 +181,7 @@ resource "rootly_escalation_level" "second" {
 - `active_all_week` (Boolean) Schedule rotation active all week?. Value must be one of true or false
 - `active_days` (List of String) Value must be one of `S`, `M`, `T`, `W`, `R`, `F`, `U`.
 - `active_time_attributes` (Block List) Schedule rotation's active times (see [below for nested schema](#nestedblock--active_time_attributes))
-- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any rootly_schedule_rotation_active_day resources linked to this schedule rotation.
+- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any schedule_rotation_active_day resources linked to this schedule rotation.
 - `end_time` (String) ISO8601 date and time when rotation ends. Shifts will only be created before this time.
 - `position` (Number) Position of the schedule rotation
 - `schedule_rotationable_type` (String) Schedule rotation type. Value must be one of `ScheduleDailyRotation`, `ScheduleWeeklyRotation`, `ScheduleBiweeklyRotation`, `ScheduleMonthlyRotation`, `ScheduleCustomRotation`.

--- a/docs/resources/schedule_rotation.md
+++ b/docs/resources/schedule_rotation.md
@@ -181,7 +181,7 @@ resource "rootly_escalation_level" "second" {
 - `active_all_week` (Boolean) Schedule rotation active all week?. Value must be one of true or false
 - `active_days` (List of String) Value must be one of `S`, `M`, `T`, `W`, `R`, `F`, `U`.
 - `active_time_attributes` (Block List) Schedule rotation's active times (see [below for nested schema](#nestedblock--active_time_attributes))
-- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any schedule_rotation_active_day resources linked to this schedule rotation.
+- `active_time_type` (String) Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override `active_time_attributes` in any `rootly_schedule_rotation_active_day` resources linked to this `rootly_schedule_rotation`.
 - `end_time` (String) ISO8601 date and time when rotation ends. Shifts will only be created before this time.
 - `position` (Number) Position of the schedule rotation
 - `schedule_rotationable_type` (String) Schedule rotation type. Value must be one of `ScheduleDailyRotation`, `ScheduleWeeklyRotation`, `ScheduleBiweeklyRotation`, `ScheduleMonthlyRotation`, `ScheduleCustomRotation`.

--- a/provider/resource_schedule_rotation.go
+++ b/provider/resource_schedule_rotation.go
@@ -87,7 +87,7 @@ func resourceScheduleRotation() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any schedule_rotation_active_day resources linked to this schedule rotation.",
+				Description: "Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override `active_time_attributes` in any `rootly_schedule_rotation_active_day` resources linked to this `rootly_schedule_rotation`.",
 			},
 
 			"active_time_attributes": &schema.Schema{

--- a/provider/resource_schedule_rotation.go
+++ b/provider/resource_schedule_rotation.go
@@ -27,9 +27,9 @@ func resourceScheduleRotation() *schema.Resource {
 
 			"schedule_id": &schema.Schema{
 				Type:        schema.TypeString,
-				Computed:    true,
-				Required:    false,
-				Optional:    true,
+				Computed:    false,
+				Required:    true,
+				Optional:    false,
 				ForceNew:    true,
 				Description: "The ID of parent schedule",
 			},
@@ -87,7 +87,7 @@ func resourceScheduleRotation() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Value must be one of `all_day`, `same_time`, or `custom`.",
+				Description: "Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any rootly_schedule_rotation_active_day resources linked to this schedule rotation.",
 			},
 
 			"active_time_attributes": &schema.Schema{

--- a/provider/resource_schedule_rotation.go
+++ b/provider/resource_schedule_rotation.go
@@ -87,7 +87,7 @@ func resourceScheduleRotation() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any rootly_schedule_rotation_active_day resources linked to this schedule rotation.",
+				Description: "Value must be one of `all_day`, `same_time`, or `custom`. The value chosen will override active_time_attributes in any schedule_rotation_active_day resources linked to this schedule rotation.",
 			},
 
 			"active_time_attributes": &schema.Schema{


### PR DESCRIPTION
## What:
<!-- Explain:
  - the scope of impact the change will have 
  - the risk of the change
  - quick highlight of what was changed
-->
Made updates to the ScheduleRotation TF Resource Docs
- made `schedule_id` a required field since it is
- made a disclaimer indicating that `active_time_type` will override any `active_time_attributes` settings for any `schedule_rotation_active_day` resources linked to the `schedule_rotation`

## Demo/Screenshots:
<img width="996" height="725" alt="Screenshot 2025-10-07 at 5 48 33 PM" src="https://github.com/user-attachments/assets/b29e04b5-5612-4f99-9bb6-9528bef7c8b4" />
<img width="1685" height="641" alt="Screenshot 2025-10-07 at 5 44 47 PM" src="https://github.com/user-attachments/assets/a0bfb6e8-c9d2-4292-b6d5-bbb32519c88a" />

## Rollback/Revert Plan
- No rollback, have to bump version

## Standard Checklist 
- [x] **Linear ticket linked and is correct ID**
- [ ] **Risk level label added to pull request**
- [ ] **Revertible** (can be safely rolled back)
  - [ ] Reversible migrations
  - [ ] Up and down migrations tested
- [ ] **Access control verified**
- [ ] **Scalable design**
- [ ] **All exceptions logged with context** (team/user/details)
- [ ] **Test coverage added or existing test cover changes**
- [ ] **OpenAPI schema updated** (if applicable)
- [ ] **Documentation updated** (if applicable)

---

## Deployment Process Checklist
- [ ] **1. Rollout plan documented in Linear by copying and pasting our [Rollout Plan Template](https://github.com/rootlyhq/rootly/wiki/Rollout-Plan-Template)**
- [ ] **2. Rollback plan documented in GitHub PR description above**
- [ ] **3. Add No QA label in Linear ticket if you are self validating**
  - [ ] If QA is need ensure a QA test plan is written out in Linear by copying and pasting our [QA testing template](https://github.com/rootlyhq/rootly/wiki/QA-Test-Plan-Template)
- [ ] **4. Deploy to staging → validate → document results in Linear as a comment by copying and pasting our [staging validation template](https://github.com/rootlyhq/rootly/wiki/Staging-Validation-Receipt-Template-For-Linear)**
- [ ] **5. Acquire queue bot → deploy to production**
- [ ] **6. Post validation receipt as comment in Linear by copying and pasting our [production validation template](https://github.com/rootlyhq/rootly/wiki/Production-Validation-Receipt-Template-For-Linear)**
