### PR TITLE
feat: Automate provider and documentation updates

### DIFF
--- a/.github/workflows/update-provider.yml
+++ b/.github/workflows/update-provider.yml
@@ -1,0 +1,66 @@
+name: update-provider
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # run at 00:00 (midnight) every day
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - uses: actions/setup-node@v5
+        with:
+          check-latest: true
+      - run: yarn install --frozen-lockfile
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Update provider
+        run: make codegen
+      - name: Update docs
+        run: make docs
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: update-provider
+          commit-message: |
+            chore: update Terraform provider and generated code
+
+            - Ran `make codegen` to regenerate resources and data sources.
+            - Updated documentation via `make docs`.
+            - Automated update to keep provider and generated documentation in sync.
+          title: |
+            chore: Automated update of provider code and documentation
+          body: |
+            ## What
+            - Run code generation to update provider resources and data sources.
+            - Regenerate documentation to reflect the current state of the provider.
+            - This PR was created automatically by a scheduled GitHub workflow.
+
+            ## Why
+            - Ensures up-to-date generated code after latest provider or API changes.
+            - Keeps documentation synced with provider implementation.
+            - Reduces manual maintenance effort.
+
+            ## How to Review
+            - Review changes to `.go` files and generated documentation (`docs/`, etc).
+            - No manual changes are included in this PR.
+            - CI tests should pass.
+
+            ---
+
+            _This PR was created by a scheduled [GitHub Actions workflow](https://github.com/rootlyhq/terraform-provider-rootly/actions/workflows/update-provider.yml)_

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,14 +16,13 @@ build: codegen docs
 
 docs:
 	terraform fmt -recursive examples
-	go get github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+	go tool tfplugindocs
 	mv ./docs/data-sources/ip_ranges.md ./docs/data-sources/ip_range.md
 	rm ./docs/data-sources/*s.md
 	mv ./docs/data-sources/ip_range.md ./docs/data-sources/ip_ranges.md
 	find ./docs/resources/*.md -type f -exec node tools/clean-docs.js {} \;
-	find ./docs/resources/workflow_task_*.md -type f -print0 | xargs -0 sed -i '' 's/subcategory:$$/subcategory: Workflow Tasks/g'
-	find ./docs/resources/workflow_*.md -type f -print0 | xargs -0 sed -i '' 's/subcategory:$$/subcategory: Workflows/g'
+	find ./docs/resources/ -type f -name 'workflow_task_*.md' -exec perl -pi -e 's/subcategory:$$/subcategory: Workflow Tasks/g' {} +
+	find ./docs/resources/ -type f -name 'workflow_*.md' -exec perl -pi -e 's/subcategory:$$/subcategory: Workflows/g' {} +
 
 release:
 	@echo "Note: Actual release building is handled by CI/GoReleaser"
@@ -54,7 +53,7 @@ testacc:
 codegen:
 	curl $(SWAGGER_URL) -o schema/swagger.json
 	node tools/clean-swagger.js schema/swagger.json
-	cd schema && oapi-codegen --config=oapi-config.yml swagger.json
+	cd schema && go tool oapi-codegen --config=oapi-config.yml swagger.json
 	node tools/generate.js schema/swagger.json
 	go fmt provider/*
 	go fmt client/*

--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,7 @@ require (
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
-tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+tool (
+	github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+	github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+)


### PR DESCRIPTION
## Overview

- Adds a GitHub Actions workflow to update the provider and regenerate documentation every night.
- Switches from `sed` to `perl` for in-place editing in the Makefile to avoid cross-platform issues.
- Uses `tfplugindocs` from the Go ecosystem for generating docs.

## Details

1. **Nightly Automation**  
   A scheduled workflow runs at midnight to update the provider and docs if there are any changes. Example: https://github.com/rootlyhq/terraform-provider-rootly/pull/129

2. **Docs Generation**  
   `tfplugindocs` is now called via Go tooling to generate up-to-date provider documentation.

3. **Perl for In-Place Editing**  
   Replaces `sed -i` with `perl -pi -e` in the Makefile. Perl works the same way on Linux and macOS, so this fixes the problems GitHub Actions running on Ubuntu-latest had with `sed`.