### PR TITLE
feat: Add new tf_diff_suppress_func propety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ Workflow tasks are special resources with dynamic generation based on OpenAPI sc
 ### Terraform Schema Flags
 The provider uses custom OpenAPI schema annotations to control Terraform resource generation behavior. These flags are processed in the JavaScript template files during code generation:
 
-- **`tf_skip_diff`** - Prevents Terraform from detecting differences on a field. Adds a `DiffSuppressFunc` that suppresses diffs when an old value exists. Used for sensitive fields like secrets or computed status fields.
+- **`tf_diff_suppress_func`** - A custom diff suppressor function. Diff functions should be implemented in the `github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc` package.
+- **`tf_skip_diff`** - Prevents Terraform from detecting differences on a field. Adds a `DiffSuppressFunc` that suppresses diffs when an old value exists. Used for sensitive fields like secrets or computed status fields. Deprecated. Use `tf_diff_suppress_func` instead with `diffsuppressfunc.Skip`.
 - **`tf_sensitive`** - Ensures that the attribute's value does not get displayed in logs or regular output.
 - **`tf_force_new`** - Indicates that any change in this field requires the resource to be destroyed and recreated.
 - **`tf_write_only`** - Used for arguments that handle secret values that do not need to be persisted in Terraform plan or state, such as passwords, API keys, etc. Write-only argument values are not sent to Terraform and do not persist in the Terraform plan or state artifact.

--- a/internal/diffsuppressfunc/skipdiff.go
+++ b/internal/diffsuppressfunc/skipdiff.go
@@ -1,0 +1,9 @@
+package diffsuppressfunc
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+var _ schema.SchemaDiffSuppressFunc = Skip
+
+func Skip(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	return len(oldValue) != 0
+}

--- a/internal/diffsuppressfunc/time.go
+++ b/internal/diffsuppressfunc/time.go
@@ -1,0 +1,44 @@
+package diffsuppressfunc
+
+import (
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var _ schema.SchemaDiffSuppressFunc = Time
+
+func Time(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	return normalizeTimeString(oldValue) == normalizeTimeString(newValue)
+}
+
+// Normalize various time formats to "15:04" (24-hour)
+func normalizeTimeString(t string) string {
+	t = strings.TrimSpace(strings.ToUpper(t))
+
+	// Attempt 24-hour format first ("08:00")
+	if parsed, err := time.Parse("15:04", t); err == nil {
+		return parsed.Format("15:04")
+	}
+
+	// Attempt common 12-hour formats
+	formats := []string{
+		"03:04PM",
+		"03:04 PM",
+		"3:04PM",
+		"3:04 PM",
+		"03:04AM",
+		"03:04 AM",
+		"3:04AM",
+		"3:04 AM",
+	}
+	for _, format := range formats {
+		if parsed, err := time.Parse(format, t); err == nil {
+			return parsed.Format("15:04")
+		}
+	}
+
+	// Fallback: return original string if no parsing worked
+	return t
+}

--- a/internal/diffsuppressfunc/time_test.go
+++ b/internal/diffsuppressfunc/time_test.go
@@ -1,0 +1,42 @@
+package diffsuppressfunc
+
+import "testing"
+
+func TestNormalizeTimeString(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// 24-hour format
+		{"08:00", "08:00"},
+		{"17:30", "17:30"},
+		{"23:59", "23:59"},
+		// 12-hour with AM/PM, various spacings
+		{"08:00 AM", "08:00"},
+		{"8:00 AM", "08:00"},
+		{"08:00AM", "08:00"},
+		{"8:00AM", "08:00"},
+		{"5:15 PM", "17:15"},
+		{"05:15 PM", "17:15"},
+		{"5:15PM", "17:15"},
+		{"05:15PM", "17:15"},
+		{"12:00PM", "12:00"},
+		{"12:00 AM", "00:00"},
+		// Lower/upper case tolerance
+		{"8:00 am", "08:00"},
+		{"5:15 pm", "17:15"},
+		// Whitespace
+		{"   09:00 AM  ", "09:00"},
+		{"  14:00 ", "14:00"},
+		// Fallback (uncleanable string, returns as is)
+		{"foo", "FOO"},
+		{"", ""},
+	}
+
+	for _, c := range cases {
+		got := normalizeTimeString(c.input)
+		if got != c.expected {
+			t.Errorf("normalizeTimeString(%q) == %q, want %q", c.input, got, c.expected)
+		}
+	}
+}

--- a/provider/resource_heartbeat.go
+++ b/provider/resource_heartbeat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
 	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
 )
 
@@ -137,19 +138,16 @@ func resourceHeartbeat() *schema.Resource {
 			},
 
 			"status": &schema.Schema{
-				Type:         schema.TypeString,
-				Computed:     true,
-				Required:     false,
-				Optional:     true,
-				Sensitive:    false,
-				ForceNew:     false,
-				WriteOnly:    false,
-				Description:  "Value must be one of `waiting`, `active`, `expired`.",
-				ValidateFunc: validation.StringInSlice([]string{"waiting", "active", "expired"}, false),
-
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return len(old) != 0
-				},
+				Type:             schema.TypeString,
+				Computed:         true,
+				Required:         false,
+				Optional:         true,
+				Sensitive:        false,
+				ForceNew:         false,
+				WriteOnly:        false,
+				Description:      "Value must be one of `waiting`, `active`, `expired`.",
+				ValidateFunc:     validation.StringInSlice([]string{"waiting", "active", "expired"}, false),
+				DiffSuppressFunc: diffsuppressfunc.Skip,
 			},
 
 			"ping_url": &schema.Schema{

--- a/provider/resource_status_page.go
+++ b/provider/resource_status_page.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
 	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
 )
 
@@ -182,18 +183,15 @@ func resourceStatusPage() *schema.Resource {
 			},
 
 			"authentication_password": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Required:    false,
-				Optional:    true,
-				Sensitive:   false,
-				ForceNew:    false,
-				WriteOnly:   false,
-				Description: "Authentication password",
-
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return len(old) != 0
-				},
+				Type:             schema.TypeString,
+				Computed:         true,
+				Required:         false,
+				Optional:         true,
+				Sensitive:        false,
+				ForceNew:         false,
+				WriteOnly:        false,
+				Description:      "Authentication password",
+				DiffSuppressFunc: diffsuppressfunc.Skip,
 			},
 
 			"saml_idp_sso_service_url": &schema.Schema{
@@ -219,18 +217,15 @@ func resourceStatusPage() *schema.Resource {
 			},
 
 			"saml_idp_cert": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Required:    false,
-				Optional:    true,
-				Sensitive:   false,
-				ForceNew:    false,
-				WriteOnly:   false,
-				Description: "SAML IdP certificate",
-
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return len(old) != 0
-				},
+				Type:             schema.TypeString,
+				Computed:         true,
+				Required:         false,
+				Optional:         true,
+				Sensitive:        false,
+				ForceNew:         false,
+				WriteOnly:        false,
+				Description:      "SAML IdP certificate",
+				DiffSuppressFunc: diffsuppressfunc.Skip,
 			},
 
 			"saml_idp_cert_fingerprint": &schema.Schema{


### PR DESCRIPTION
- Add a new `tf_diff_suppress_func`.  
- Deprecate `tf_skip_diff` in favor of setting `tf_diff_suppress_func` with `diffsuppressfunc.Skip`.  
- Implement `diffsuppressfunc.Time` to semantically match various time formats, e.g., `13:00` == `01:00 PM`.