### PR TITLE
Fix custom_field_id type from int to string for UUID support

### DIFF
--- a/client/workflow_custom_field_selections.go
+++ b/client/workflow_custom_field_selections.go
@@ -13,7 +13,7 @@ import (
 type WorkflowCustomFieldSelection struct {
 	ID                string        `jsonapi:"primary,workflow_custom_field_selections"`
 	WorkflowId        string        `jsonapi:"attr,workflow_id,omitempty"`
-	CustomFieldId     int           `jsonapi:"attr,custom_field_id,omitempty"`
+	CustomFieldId     string        `jsonapi:"attr,custom_field_id,omitempty"`
 	IncidentCondition string        `jsonapi:"attr,incident_condition,omitempty"`
 	Values            []interface{} `jsonapi:"attr,values,omitempty"`
 	SelectedOptionIds []interface{} `jsonapi:"attr,selected_option_ids,omitempty"`

--- a/provider/resource_workflow_custom_field_selection.go
+++ b/provider/resource_workflow_custom_field_selection.go
@@ -38,7 +38,7 @@ func resourceWorkflowCustomFieldSelection() *schema.Resource {
 			},
 
 			"custom_field_id": &schema.Schema{
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Computed:    false,
 				Required:    true,
 				Optional:    false,
@@ -104,7 +104,7 @@ func resourceWorkflowCustomFieldSelectionCreate(ctx context.Context, d *schema.R
 		s.WorkflowId = value.(string)
 	}
 	if value, ok := d.GetOkExists("custom_field_id"); ok {
-		s.CustomFieldId = value.(int)
+		s.CustomFieldId = value.(string)
 	}
 	if value, ok := d.GetOkExists("incident_condition"); ok {
 		s.IncidentCondition = value.(string)
@@ -163,7 +163,7 @@ func resourceWorkflowCustomFieldSelectionUpdate(ctx context.Context, d *schema.R
 		s.WorkflowId = d.Get("workflow_id").(string)
 	}
 	if d.HasChange("custom_field_id") {
-		s.CustomFieldId = d.Get("custom_field_id").(int)
+		s.CustomFieldId = d.Get("custom_field_id").(string)
 	}
 	if d.HasChange("incident_condition") {
 		s.IncidentCondition = d.Get("incident_condition").(string)


### PR DESCRIPTION
## Summary

This PR fixes the `rootly_workflow_custom_field_selection` resource to use `string` type for the `custom_field_id` field instead of `int`, allowing it to properly handle UUID values returned by the Rootly API.

## Problem

The Rootly API was updated to return UUID strings for `custom_field_id` (instead of legacy integer IDs), which caused the Terraform provider to fail with the following error:

```
Error: Error creating workflow_custom_field_selection: Error unmarshaling workflow_custom_field_selection: Invalid type provided
```

The issue occurred because:
- The API now returns UUID strings like `"550e8400-e29b-41d4-a716-446655440000"`
- The provider expected integer values like `123`
- Go's JSON unmarshaling failed when trying to parse a string into an `int` field

## Changes

### `client/workflow_custom_field_selections.go`
- Changed `CustomFieldId` field from `int` to `string` in the `WorkflowCustomFieldSelection` struct

### `provider/resource_workflow_custom_field_selection.go`
- Updated schema definition from `schema.TypeInt` to `schema.TypeString`
- Updated Create function to use `value.(string)` instead of `value.(int)`
- Updated Update function to use `.Get("custom_field_id").(string)` instead of `.(int)`

## Testing

This fix resolves the failing test in `resource_workflow_custom_field_selection_test.go`:
- ✅ Resource creation now accepts UUID strings
- ✅ Resource reads correctly handle UUID strings  
- ✅ Resource updates work with UUID strings

## Related Changes

- **Rootly API PR**: https://github.com/rootlyhq/rootly/pull/13791
  - Updated API to accept UUID strings for `custom_field_id` in CREATE requests
  - Ensured consistency between CREATE (accepts UUID) and READ (returns UUID) operations

## Deployment Notes

- This PR should be deployed **after** or **simultaneously with** the Rootly API PR
- No breaking changes for existing resources (UUIDs are parsed as strings)
- Backward compatible as the API validates the UUID format

## Checklist

- [x] Changes are backward compatible
- [x] All type conversions updated (Create, Read, Update)
- [x] Schema definition updated
- [x] Client struct updated
- [x] Related to failing test: resource_workflow_custom_field_selection_test.go