### PR TITLE
chore: Upgrade Terraform version used in tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,10 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
-      -
-        name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,11 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24'
-      id: go
+    - uses: actions/checkout@v5
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
 
     - name: Get dependencies
       run: |
@@ -56,25 +53,19 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          #- '0.14.*'
-          #- '0.15.*'
-          #- '1.0.*'
-          - '1.1.*'
+          - '1.13.*'
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
-      id: go
+        go-version-file: go.mod
 
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
1. Source go version from go.mod file
2. Upgrade Terraform version used in tests to `v1.13.*` (was `v1.1.*`)