### PR TITLE
fix(rootly_dashboard_panel): Fix import errors when legend is not provided

### DIFF
--- a/internal/converter/expand.go
+++ b/internal/converter/expand.go
@@ -22,6 +22,11 @@ func Expand(i any, s *schema.Schema) (any, error) {
 			return nil, errors.New("not a map")
 		}
 
+		// If it's an empty object {}, assume nil
+		if len(ii) == 0 {
+			return nil, nil
+		}
+
 		res := s.Elem.(*schema.Resource)
 		m := make(map[string]any, len(res.Schema))
 		for k, s := range res.Schema {

--- a/provider/resource_dashboard_panel_test.go
+++ b/provider/resource_dashboard_panel_test.go
@@ -104,6 +104,62 @@ func TestAccResourceDashboardPanel_UpgradeFromVersion(t *testing.T) {
 	})
 }
 
+func TestAccResourceDashboardPanel_Import(t *testing.T) {
+	resName := "rootly_dashboard_panel.foo"
+	dashboardName := acctest.RandomWithPrefix("tf-dashboard")
+
+	config := fmt.Sprintf(`
+		resource "rootly_dashboard" "foo" {
+			name = "%[1]s"
+		}
+
+		resource "rootly_dashboard_panel" "foo" {
+			dashboard_id = rootly_dashboard.foo.id
+			name = "test"
+			position {
+				x = 3
+				y = 4
+				h = 5
+				w = 6
+			}
+			params {
+				display = "line_chart"
+			}
+		}
+	`, dashboardName)
+
+	check := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(resName, "name", "test"),
+		resource.TestCheckResourceAttr(resName, "position.#", "1"),
+		resource.TestCheckResourceAttr(resName, "position.0.x", "3"),
+		resource.TestCheckResourceAttr(resName, "position.0.y", "4"),
+		resource.TestCheckResourceAttr(resName, "position.0.h", "5"),
+		resource.TestCheckResourceAttr(resName, "position.0.w", "6"),
+		resource.TestCheckResourceAttr(resName, "params.#", "1"),
+		resource.TestCheckResourceAttr(resName, "params.0.display", "line_chart"),
+		resource.TestCheckResourceAttr(resName, "params.0.legend.#", "0"),
+		resource.TestCheckResourceAttr(resName, "params.0.datasets.#", "0"),
+	)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  check,
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceDashboardPanel(t *testing.T) {
 	resName := "rootly_dashboard_panel.foo"
 


### PR DESCRIPTION
https://linear.app/rootly/issue/IR-2503/import-error-for-rootly-dashboard-panel-resource

Treat empty object `{}` as `null` so that the resource imports correctly.