### PR TITLE
[OC-3277]: Add `delete` permission to `alerts_permissions` of `on_call_role` resource

### DIFF
--- a/docs/resources/on_call_role.md
+++ b/docs/resources/on_call_role.md
@@ -25,7 +25,7 @@ description: |-
 - `alert_routing_rules_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `alert_sources_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `alert_urgency_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
-- `alerts_permissions` (List of String) Value must be one of `create`, `update`, `read`.
+- `alerts_permissions` (List of String) Value must be one of `create`, `update`, `read`, `delete`.
 - `api_keys_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `audits_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `contacts_permissions` (List of String) Value must be one of `read`.
@@ -35,7 +35,7 @@ description: |-
 - `integrations_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `invitations_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `live_call_routing_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
-- `on_call_readiness_report_permissions` (List of String) Value must be only `read`
+- `on_call_readiness_report_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `on_call_roles_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.
 - `schedule_override_permissions` (List of String) Value must be one of `create`, `update`.
 - `schedules_permissions` (List of String) Value must be one of `create`, `read`, `update`, `delete`.

--- a/provider/resource_on_call_role.go
+++ b/provider/resource_on_call_role.go
@@ -168,7 +168,7 @@ func resourceOnCallRole() *schema.Resource {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"create", "update", "read"}, false),
+					ValidateFunc: validation.StringInSlice([]string{"create", "update", "read", "delete"}, false),
 				},
 				DiffSuppressFunc: tools.EqualIgnoringOrder,
 				Computed:         true,
@@ -177,7 +177,7 @@ func resourceOnCallRole() *schema.Resource {
 				Sensitive:        false,
 				ForceNew:         false,
 				WriteOnly:        false,
-				Description:      "Value must be one of `create`, `update`, `read`.",
+				Description:      "Value must be one of `create`, `update`, `read`, `delete`.",
 			},
 
 			"api_keys_permissions": &schema.Schema{


### PR DESCRIPTION
## Description

Add `delete` permission to `alerts_permissions` of the `on_call_role` resource.

## Motivation

Since the API returns `delete` as a valid `alerts_permissions`, the TF provider has been adjusted accordingly.

## Testing

- [ ] Added new tests for this functionality
- [ ] Existing tests cover this change
- [x] No tests needed

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)
