### PR TITLE
Fix rootly_functionality service_ids plan consistency

### DIFF
--- a/provider/resource_functionality.go
+++ b/provider/resource_functionality.go
@@ -75,7 +75,7 @@ func resourceFunctionality() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				DiffSuppressFunc: tools.EqualIgnoringOrder,
-				Computed:         false,
+				Computed:         true,
 				Required:         false,
 				Optional:         true,
 				Sensitive:        false,

--- a/provider/resource_functionality_service_ids_test.go
+++ b/provider/resource_functionality_service_ids_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceFunctionality_serviceIdsWithNewService(t *testing.T) {
+	serviceName := acctest.RandomWithPrefix("tf-service")
+	functionalityName := acctest.RandomWithPrefix("tf-functionality")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceFunctionalityServiceIdsConfig(serviceName, functionalityName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_functionality.test", "name", functionalityName),
+					resource.TestCheckResourceAttr("rootly_functionality.test", "service_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("rootly_functionality.test", "service_ids.0", "rootly_service.test", "id"),
+				),
+			},
+			{
+				Config:   testAccResourceFunctionalityServiceIdsConfig(serviceName, functionalityName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccResourceFunctionalityServiceIdsConfig(serviceName, functionalityName string) string {
+	return fmt.Sprintf(`
+resource "rootly_service" "test" {
+  name = "%s"
+}
+
+resource "rootly_functionality" "test" {
+  name       = "%s"
+  service_ids = [rootly_service.test.id]
+}
+`, serviceName, functionalityName)
+}

--- a/tools/v2-migration-utils.ts
+++ b/tools/v2-migration-utils.ts
@@ -44,4 +44,9 @@ export const SchemaMods: SchemaMod[] = [
 
     return schema;
   },
+  function fixFunctionalityServiceIds(schema) {
+    schema.components.schemas["functionality"].properties["service_ids"].tf_computed = true;
+
+    return schema;
+  },
 ];


### PR DESCRIPTION
## Problem
`rootly_functionality` can fail during `apply` with `Provider produced inconsistent final plan` when `service_ids` depends on `rootly_service` resources that are being created or replaced in the same apply.

A minimal configuration shape is:

```hcl
resource "rootly_service" "test" {
  name = "example-service"
}

resource "rootly_functionality" "test" {
  name        = "example-functionality"
  service_ids = [rootly_service.test.id]
}
```

In the failing case, the `rootly_service.test.id` value is not known at plan time. The provider ends up planning `service_ids` as `null`, but during apply it returns a concrete list of IDs. OpenTofu/Terraform rejects that `null -> known list` transition as an inconsistent final plan.

The original report that motivated this change reproduced the issue on OpenTofu `1.11.3` with `rootlyhq/rootly` `5.9.2`, and the same pattern also showed up during larger taxonomy refactors where many `rootly_service` and `rootly_functionality` resources were renamed or replaced in a single apply.

Representative failure:

```text
Error: Provider produced inconsistent final plan

... produced an invalid new value for .service_ids: was null, but now cty.ListVal(...)
```

## Root Cause
`rootly_functionality.service_ids` is currently defined as optional, but not computed, while the provider also writes the API value back into state during `Read`.

That combination is unsafe for values that may be unknown during planning. When `service_ids` is derived from sibling managed resource IDs, the provider needs Terraform/OpenTofu to preserve an unknown planned value until apply. Instead, the current schema allows the planned value to collapse to `null`, and the later read of concrete IDs triggers the data consistency error.

In practice, the problematic combination is:
- `service_ids` is `Optional: true` and `Computed: false`
- `Read` unconditionally sets `service_ids` from the API response

## Fix
This PR marks `rootly_functionality.service_ids` as computed so the attribute is treated as `Optional + Computed`.

That allows Terraform/OpenTofu to accept the attribute being populated during apply when the IDs become known.

The change includes:
- updating the generated functionality resource schema to mark `service_ids` as computed
- adding a schema mod in `tools/v2-migration-utils.ts` so regeneration preserves the fix
- adding a focused functionality test covering the case where a functionality references a newly created service

## Why This Change
This is the minimal fix that addresses the reported failure without changing resource behavior or introducing a new association resource.

It preserves the existing user-facing configuration shape:
- users can still set `service_ids` explicitly
- the provider can still read the API value back into state
- create/replace operations that depend on sibling `rootly_service` IDs no longer hit the inconsistent-final-plan error

## Testing
Added a regression-style test for a functionality whose `service_ids` references a newly created `rootly_service`.

Locally I ran a lightweight provider compile/validation check:

```bash
env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./provider -run '^TestProvider$' -count=1
```

I did not run the full acceptance suite in this environment.

## Transparency
This PR was prepared with the help of AI tools, and the proposed change set was reviewed before submission.
