### PR TITLE
Update descriptions of attributes and some tests in SLA

### DIFF
--- a/docs/resources/sla.md
+++ b/docs/resources/sla.md
@@ -44,20 +44,29 @@ resource "rootly_sla" "critical" {
   name                              = "Critical Incident SLA"
   description                       = "Stricter deadlines for SEV0 and SEV1 incidents"
   condition_match_type              = "ALL"
-  assignment_deadline_days          = 1
+  assignment_deadline_days          = 3
   assignment_deadline_parent_status = "started"
   assignment_skip_weekends          = false
-  completion_deadline_days          = 3
+  completion_deadline_days          = 5
   completion_deadline_parent_status = "resolved"
   completion_skip_weekends          = false
   manager_role_id                   = data.rootly_incident_role.commander.id
 
-  # Match only SEV0 and SEV1 incidents
+  # is_one_of: match incidents with SEV0 or SEV1 severity.
+  # Note: `values` takes resource IDs (not display names like "SEV0").
+  # Use a data source to look up the ID first.
   conditions {
     conditionable_type = "SLAs::BuiltInFieldCondition"
     property           = "severity"
     operator           = "is_one_of"
     values             = [data.rootly_severity.sev0.id, data.rootly_severity.sev1.id]
+  }
+
+  # is_set: require that the environment field is present (no values needed)
+  conditions {
+    conditionable_type = "SLAs::BuiltInFieldCondition"
+    property           = "environment"
+    operator           = "is_set"
   }
 
   # Notify 1 day before the deadline, when due, and 1 day after
@@ -77,7 +86,7 @@ resource "rootly_sla" "critical" {
   }
 }
 
-# SLA with a custom field condition
+# SLA with a custom field condition using the "contains" operator (single value)
 resource "rootly_sla" "compliance" {
   name                              = "Compliance Review SLA"
   assignment_deadline_days          = 2
@@ -86,11 +95,12 @@ resource "rootly_sla" "compliance" {
   completion_deadline_parent_status = "resolved"
   manager_role_id                   = data.rootly_incident_role.commander.id
 
+  # contains: match when the custom field value contains a substring
   conditions {
     conditionable_type = "SLAs::CustomFieldCondition"
     form_field_id      = "your-custom-field-uuid"
-    operator           = "is_one_of"
-    values             = ["option-value-1", "option-value-2"]
+    operator           = "contains"
+    values             = ["production"]
   }
 }
 ```
@@ -108,16 +118,16 @@ resource "rootly_sla" "compliance" {
 
 ### Optional
 
-- `assignment_deadline_sub_status_id` (String) Optional sub-status for the assignment deadline
+- `assignment_deadline_sub_status_id` (String) Sub-status for the assignment deadline. Required when custom lifecycle statuses are enabled on the team.
 - `assignment_skip_weekends` (Boolean) Whether to skip weekends when calculating the assignment deadline. Value must be one of true or false
-- `completion_deadline_sub_status_id` (String) Optional sub-status for the completion deadline
+- `completion_deadline_sub_status_id` (String) Sub-status for the completion deadline. Required when custom lifecycle statuses are enabled on the team.
 - `completion_skip_weekends` (Boolean) Whether to skip weekends when calculating the completion deadline. Value must be one of true or false
 - `condition_match_type` (String) Whether all or any conditions must match. Value must be one of `ALL`, `ANY`.
 - `conditions` (Block List) Conditions that determine which incidents this SLA applies to (see [below for nested schema](#nestedblock--conditions))
 - `description` (String) A description of the SLA
 - `entity_type` (String) The entity type this SLA applies to. Value must be one of `follow_up`.
-- `manager_role_id` (String) The ID of the manager incident role
-- `manager_user_id` (Number) The ID of the manager user
+- `manager_role_id` (String) The ID of the manager incident role. Exactly one of `manager_role_id` or `manager_user_id` must be provided.
+- `manager_user_id` (Number) The ID of the manager user. Exactly one of `manager_role_id` or `manager_user_id` must be provided.
 - `notification_configurations` (Block List) Notification timing configurations (see [below for nested schema](#nestedblock--notification_configurations))
 - `position` (Number) Position of the SLA for ordering
 - `slug` (String) The slug of the SLA

--- a/provider/data_source_sla_test.go
+++ b/provider/data_source_sla_test.go
@@ -65,6 +65,14 @@ func TestAccDataSourceSLA_bySlug(t *testing.T) {
 
 func testAccDataSourceSLAResourcesOnly(name string) string {
 	return fmt.Sprintf(`
+data "rootly_sub_status" "started" {
+	parent_status = "started"
+}
+
+data "rootly_sub_status" "resolved" {
+	parent_status = "resolved"
+}
+
 resource "rootly_incident_role" "test" {
 	name = "tf-test-ds-sla-manager-%s"
 }
@@ -73,8 +81,10 @@ resource "rootly_sla" "test" {
 	name                              = "%s"
 	assignment_deadline_days          = 3
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 7
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.test.id
 }
 `, name, name)

--- a/provider/resource_sla.go
+++ b/provider/resource_sla.go
@@ -102,7 +102,7 @@ func resourceSLA() *schema.Resource {
 				Sensitive:   false,
 				ForceNew:    false,
 				WriteOnly:   false,
-				Description: "The ID of the manager incident role",
+				Description: "The ID of the manager incident role. Exactly one of `manager_role_id` or `manager_user_id` must be provided.",
 			},
 
 			"manager_user_id": &schema.Schema{
@@ -113,7 +113,7 @@ func resourceSLA() *schema.Resource {
 				Sensitive:   false,
 				ForceNew:    false,
 				WriteOnly:   false,
-				Description: "The ID of the manager user",
+				Description: "The ID of the manager user. Exactly one of `manager_role_id` or `manager_user_id` must be provided.",
 			},
 
 			"assignment_deadline_days": &schema.Schema{
@@ -146,7 +146,7 @@ func resourceSLA() *schema.Resource {
 				Sensitive:   false,
 				ForceNew:    false,
 				WriteOnly:   false,
-				Description: "Optional sub-status for the assignment deadline",
+				Description: "Sub-status for the assignment deadline. Required when custom lifecycle statuses are enabled on the team.",
 			},
 
 			"assignment_skip_weekends": &schema.Schema{
@@ -190,7 +190,7 @@ func resourceSLA() *schema.Resource {
 				Sensitive:   false,
 				ForceNew:    false,
 				WriteOnly:   false,
-				Description: "Optional sub-status for the completion deadline",
+				Description: "Sub-status for the completion deadline. Required when custom lifecycle statuses are enabled on the team.",
 			},
 
 			"completion_skip_weekends": &schema.Schema{

--- a/provider/resource_sla_test.go
+++ b/provider/resource_sla_test.go
@@ -119,11 +119,18 @@ func TestAccResourceSLA_withNotifications(t *testing.T) {
 	})
 }
 
-// managerRoleConfig returns a unique incident_role block so tests that share
-// the same test binary (or previous runs that leaked roles) don't collide on
-// the "name must be unique" constraint.
-func managerRoleConfig(suffix string) string {
+// slaBaseConfig returns shared data sources (sub-statuses) and a uniquely-named
+// incident_role so tests don't collide on the "name must be unique" constraint.
+func slaBaseConfig(suffix string) string {
 	return fmt.Sprintf(`
+data "rootly_sub_status" "started" {
+	parent_status = "started"
+}
+
+data "rootly_sub_status" "resolved" {
+	parent_status = "resolved"
+}
+
 resource "rootly_incident_role" "test" {
 	name = "tf-test-sla-manager-%s"
 }
@@ -131,29 +138,33 @@ resource "rootly_incident_role" "test" {
 }
 
 func testAccResourceSLABasic(name string) string {
-	return managerRoleConfig(name) + fmt.Sprintf(`
+	return slaBaseConfig(name) + fmt.Sprintf(`
 resource "rootly_sla" "test" {
 	name                              = "%s"
 	assignment_deadline_days          = 3
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 7
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.test.id
 }
 `, name)
 }
 
 func testAccResourceSLAUpdated(name, roleSuffix string) string {
-	return managerRoleConfig(roleSuffix) + fmt.Sprintf(`
+	return slaBaseConfig(roleSuffix) + fmt.Sprintf(`
 resource "rootly_sla" "test" {
 	name                              = "%s"
 	description                       = "Updated description"
 	condition_match_type              = "ANY"
 	assignment_deadline_days          = 5
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	assignment_skip_weekends          = true
 	completion_deadline_days          = 14
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	completion_skip_weekends          = true
 	manager_role_id                   = rootly_incident_role.test.id
 }
@@ -161,13 +172,15 @@ resource "rootly_sla" "test" {
 }
 
 func testAccResourceSLAWithConditions(name string) string {
-	return managerRoleConfig(name) + fmt.Sprintf(`
+	return slaBaseConfig(name) + fmt.Sprintf(`
 resource "rootly_sla" "test" {
 	name                              = "%s"
 	assignment_deadline_days          = 2
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 7
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.test.id
 
 	conditions {
@@ -180,13 +193,15 @@ resource "rootly_sla" "test" {
 }
 
 func testAccResourceSLAWithNotifications(name string) string {
-	return managerRoleConfig(name) + fmt.Sprintf(`
+	return slaBaseConfig(name) + fmt.Sprintf(`
 resource "rootly_sla" "test" {
 	name                              = "%s"
 	assignment_deadline_days          = 3
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 7
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.test.id
 
 	notification_configurations {
@@ -260,6 +275,14 @@ func TestAccResourceSLA_example(t *testing.T) {
 
 func testAccResourceSLAExample(suffix string) string {
 	return fmt.Sprintf(`
+data "rootly_sub_status" "started" {
+	parent_status = "started"
+}
+
+data "rootly_sub_status" "resolved" {
+	parent_status = "resolved"
+}
+
 resource "rootly_severity" "sev0" {
 	name     = "%[1]s-sev0"
 	severity = "low"
@@ -286,8 +309,10 @@ resource "rootly_sla" "basic" {
 	description                       = "Ensure follow-ups are assigned and completed on time"
 	assignment_deadline_days          = 3
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 7
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.commander.id
 }
 
@@ -298,9 +323,11 @@ resource "rootly_sla" "critical" {
 	condition_match_type              = "ALL"
 	assignment_deadline_days          = 3
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	assignment_skip_weekends          = false
 	completion_deadline_days          = 5
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	completion_skip_weekends          = false
 	manager_role_id                   = rootly_incident_role.commander.id
 
@@ -340,8 +367,10 @@ resource "rootly_sla" "compliance" {
 	name                              = "%[1]s-compliance"
 	assignment_deadline_days          = 2
 	assignment_deadline_parent_status = "started"
+	assignment_deadline_sub_status_id = data.rootly_sub_status.started.id
 	completion_deadline_days          = 5
 	completion_deadline_parent_status = "resolved"
+	completion_deadline_sub_status_id = data.rootly_sub_status.resolved.id
 	manager_role_id                   = rootly_incident_role.commander.id
 
 	# contains: single value, custom field condition


### PR DESCRIPTION
# Description

## Summary
- Update `manager_role_id` and `manager_user_id` descriptions to clarify that exactly one must be provided
- Update `assignment_deadline_sub_status_id` and `completion_deadline_sub_status_id` descriptions to note they are required when custom lifecycle statuses are enabled. We need this NOW because we made a behavioural change  in the API.


# Motivation

# Testing
 

- [ ] Added new tests for this functionality
- [ ] Existing tests cover this change
- [ ] No tests needed (explain why below)

# Risk Assessment

- [ ] Added risk level label (low/medium/high risk)