### PR TITLE
[OC-3569] Add escalation policy id and functionality paging targets

### DIFF
--- a/client/functionalities.go
+++ b/client/functionalities.go
@@ -11,28 +11,29 @@ import (
 )
 
 type Functionality struct {
-	ID                string        `jsonapi:"primary,functionalities"`
-	Name              string        `jsonapi:"attr,name,omitempty"`
-	Slug              string        `jsonapi:"attr,slug,omitempty"`
-	Description       string        `jsonapi:"attr,description,omitempty"`
-	PublicDescription string        `jsonapi:"attr,public_description,omitempty"`
-	NotifyEmails      []interface{} `jsonapi:"attr,notify_emails,omitempty"`
-	Color             string        `jsonapi:"attr,color,omitempty"`
-	BackstageId       string        `jsonapi:"attr,backstage_id,omitempty"`
-	ExternalId        string        `jsonapi:"attr,external_id,omitempty"`
-	PagerdutyId       string        `jsonapi:"attr,pagerduty_id,omitempty"`
-	OpsgenieId        string        `jsonapi:"attr,opsgenie_id,omitempty"`
-	OpsgenieTeamId    string        `jsonapi:"attr,opsgenie_team_id,omitempty"`
-	CortexId          string        `jsonapi:"attr,cortex_id,omitempty"`
-	ServiceNowCiSysId string        `jsonapi:"attr,service_now_ci_sys_id,omitempty"`
-	Position          int           `jsonapi:"attr,position,omitempty"`
-	EnvironmentIds    []interface{} `jsonapi:"attr,environment_ids,omitempty"`
-	ServiceIds        []interface{} `jsonapi:"attr,service_ids,omitempty"`
-	OwnerGroupIds     []interface{} `jsonapi:"attr,owner_group_ids,omitempty"`
-	OwnerUserIds      []interface{} `jsonapi:"attr,owner_user_ids,omitempty"`
-	SlackChannels     []interface{} `jsonapi:"attr,slack_channels,omitempty"`
-	SlackAliases      []interface{} `jsonapi:"attr,slack_aliases,omitempty"`
-	Properties        []interface{} `jsonapi:"attr,properties,omitempty"`
+	ID                 string        `jsonapi:"primary,functionalities"`
+	Name               string        `jsonapi:"attr,name,omitempty"`
+	Slug               string        `jsonapi:"attr,slug,omitempty"`
+	Description        string        `jsonapi:"attr,description,omitempty"`
+	PublicDescription  string        `jsonapi:"attr,public_description,omitempty"`
+	NotifyEmails       []interface{} `jsonapi:"attr,notify_emails,omitempty"`
+	Color              string        `jsonapi:"attr,color,omitempty"`
+	BackstageId        string        `jsonapi:"attr,backstage_id,omitempty"`
+	ExternalId         string        `jsonapi:"attr,external_id,omitempty"`
+	PagerdutyId        string        `jsonapi:"attr,pagerduty_id,omitempty"`
+	OpsgenieId         string        `jsonapi:"attr,opsgenie_id,omitempty"`
+	OpsgenieTeamId     string        `jsonapi:"attr,opsgenie_team_id,omitempty"`
+	CortexId           string        `jsonapi:"attr,cortex_id,omitempty"`
+	ServiceNowCiSysId  string        `jsonapi:"attr,service_now_ci_sys_id,omitempty"`
+	Position           int           `jsonapi:"attr,position,omitempty"`
+	EnvironmentIds     []interface{} `jsonapi:"attr,environment_ids,omitempty"`
+	ServiceIds         []interface{} `jsonapi:"attr,service_ids,omitempty"`
+	OwnerGroupIds      []interface{} `jsonapi:"attr,owner_group_ids,omitempty"`
+	OwnerUserIds       []interface{} `jsonapi:"attr,owner_user_ids,omitempty"`
+	EscalationPolicyId string        `jsonapi:"attr,escalation_policy_id,omitempty"`
+	SlackChannels      []interface{} `jsonapi:"attr,slack_channels,omitempty"`
+	SlackAliases       []interface{} `jsonapi:"attr,slack_aliases,omitempty"`
+	Properties         []interface{} `jsonapi:"attr,properties,omitempty"`
 }
 
 func (c *Client) ListFunctionalities(params *rootlygo.ListFunctionalitiesParams) ([]interface{}, error) {

--- a/docs/resources/alert_group.md
+++ b/docs/resources/alert_group.md
@@ -91,8 +91,8 @@ Optional:
 
 Optional:
 
-- `target_id` (String) id for the Group, Service or EscalationPolicy
-- `target_type` (String) The type of the target.. Value must be one of `Group`, `Service`, `EscalationPolicy`.
+- `target_id` (String) id for the Group, Service, Functionality or EscalationPolicy
+- `target_type` (String) The type of the target.. Value must be one of `Group`, `Service`, `Functionality`, `EscalationPolicy`.
 
 ## Import
 

--- a/docs/resources/alert_routing_rule.md
+++ b/docs/resources/alert_routing_rule.md
@@ -43,7 +43,7 @@ Required:
 
 Optional:
 
-- `target_type` (String) The type of the target. Value must be one of `Service`, `Group`, `EscalationPolicy`.
+- `target_type` (String) The type of the target. Value must be one of `Service`, `Group`, `Functionality`, `EscalationPolicy`.
 
 
 <a id="nestedblock--condition_groups"></a>

--- a/docs/resources/functionality.md
+++ b/docs/resources/functionality.md
@@ -63,6 +63,7 @@ resource "rootly_functionality" "logging_in" {
 - `cortex_id` (String) The Cortex group id associated to this functionality
 - `description` (String) The description of the functionality
 - `environment_ids` (List of String) Environments associated with this functionality
+- `escalation_policy_id` (String) The escalation policy id of the functionality
 - `external_id` (String) The external id associated to this functionality
 - `notify_emails` (List of String) Emails attached to the functionality
 - `opsgenie_id` (String) The Opsgenie service id associated to this functionality

--- a/docs/resources/heartbeat.md
+++ b/docs/resources/heartbeat.md
@@ -31,7 +31,7 @@ description: |-
 - `expires_at` (String) When heartbeat expires
 - `interval_unit` (String) Value must be one of `minutes`, `hours`.
 - `last_pinged_at` (String) When the heartbeat was last pinged.
-- `notification_target_type` (String) Value must be one of `User`, `Group`, `Service`, `EscalationPolicy`.
+- `notification_target_type` (String) Value must be one of `User`, `Group`, `Service`, `EscalationPolicy`, `Functionality`.
 - `status` (String) Value must be one of `waiting`, `active`, `expired`.
 
 ### Read-Only

--- a/provider/resource_alert_group.go
+++ b/provider/resource_alert_group.go
@@ -126,8 +126,8 @@ func resourceAlertGroup() *schema.Resource {
 							Sensitive:    false,
 							ForceNew:     false,
 							WriteOnly:    false,
-							Description:  "The type of the target.. Value must be one of `Group`, `Service`, `EscalationPolicy`.",
-							ValidateFunc: validation.StringInSlice([]string{"Group", "Service", "EscalationPolicy"}, false),
+							Description:  "The type of the target.. Value must be one of `Group`, `Service`, `Functionality`, `EscalationPolicy`.",
+							ValidateFunc: validation.StringInSlice([]string{"Group", "Service", "Functionality", "EscalationPolicy"}, false),
 						},
 
 						"target_id": &schema.Schema{

--- a/provider/resource_alert_routing_rule.go
+++ b/provider/resource_alert_routing_rule.go
@@ -179,8 +179,8 @@ func resourceAlertRoutingRule() *schema.Resource {
 							Sensitive:    false,
 							ForceNew:     false,
 							WriteOnly:    false,
-							Description:  "The type of the target. Value must be one of `Service`, `Group`, `EscalationPolicy`.",
-							ValidateFunc: validation.StringInSlice([]string{"Service", "Group", "EscalationPolicy"}, false),
+							Description:  "The type of the target. Value must be one of `Service`, `Group`, `Functionality`, `EscalationPolicy`.",
+							ValidateFunc: validation.StringInSlice([]string{"Service", "Group", "Functionality", "EscalationPolicy"}, false),
 						},
 
 						"target_id": &schema.Schema{

--- a/provider/resource_functionality.go
+++ b/provider/resource_functionality.go
@@ -243,6 +243,17 @@ func resourceFunctionality() *schema.Resource {
 				Description:      "Owner Users associated with this functionality",
 			},
 
+			"escalation_policy_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Required:    false,
+				Optional:    true,
+				Sensitive:   false,
+				ForceNew:    false,
+				WriteOnly:   false,
+				Description: "The escalation policy id of the functionality",
+			},
+
 			"slack_channels": &schema.Schema{
 				Type:             schema.TypeList,
 				Computed:         false,
@@ -421,6 +432,9 @@ func resourceFunctionalityCreate(ctx context.Context, d *schema.ResourceData, me
 	if value, ok := d.GetOkExists("owner_user_ids"); ok {
 		s.OwnerUserIds = value.([]interface{})
 	}
+	if value, ok := d.GetOkExists("escalation_policy_id"); ok {
+		s.EscalationPolicyId = value.(string)
+	}
 	if value, ok := d.GetOkExists("slack_channels"); ok {
 		s.SlackChannels = value.([]interface{})
 	}
@@ -477,6 +491,7 @@ func resourceFunctionalityRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("service_ids", item.ServiceIds)
 	d.Set("owner_group_ids", item.OwnerGroupIds)
 	d.Set("owner_user_ids", item.OwnerUserIds)
+	d.Set("escalation_policy_id", item.EscalationPolicyId)
 
 	if item.SlackChannels != nil {
 		processed_items_slack_channels := make([]map[string]interface{}, 0)
@@ -623,6 +638,10 @@ func resourceFunctionalityUpdate(ctx context.Context, d *schema.ResourceData, me
 		} else {
 			s.OwnerUserIds = []interface{}{}
 		}
+	}
+
+	if d.HasChange("escalation_policy_id") {
+		s.EscalationPolicyId = d.Get("escalation_policy_id").(string)
 	}
 
 	if d.HasChange("slack_channels") {

--- a/provider/resource_heartbeat.go
+++ b/provider/resource_heartbeat.go
@@ -124,8 +124,8 @@ func resourceHeartbeat() *schema.Resource {
 				Sensitive:    false,
 				ForceNew:     false,
 				WriteOnly:    false,
-				Description:  "Value must be one of `User`, `Group`, `Service`, `EscalationPolicy`.",
-				ValidateFunc: validation.StringInSlice([]string{"User", "Group", "Service", "EscalationPolicy"}, false),
+				Description:  "Value must be one of `User`, `Group`, `Service`, `EscalationPolicy`, `Functionality`.",
+				ValidateFunc: validation.StringInSlice([]string{"User", "Group", "Service", "EscalationPolicy", "Functionality"}, false),
 			},
 
 			"enabled": &schema.Schema{


### PR DESCRIPTION
## Summary

Closes [OC-3569](https://linear.app/rootly/issue/OC-3569/tf-allow-people-to-createedit-a-functionality-with-an-escalation).

- Adds `escalation_policy_id` to `rootly_functionality` (create / read / update). Mirrors what [#178 (OC-2397)](https://github.com/rootlyhq/terraform-provider-rootly/commit/73f7dcf) did for `rootly_service`.
- Widens `rootly_alert_routing_rule.destination.target_type` to accept `Functionality` (now `Service` / `Group` / `Functionality` / `EscalationPolicy`).
- Widens `rootly_heartbeat.notification_target_type` to accept `Functionality` (now `User` / `Group` / `Service` / `EscalationPolicy` / `Functionality`).
- Widens `rootly_alert_group.targets[].target_type` to accept `Functionality` (now `Group` / `Service` / `Functionality` / `EscalationPolicy`). API support added in [rootlyhq/rootly#17564](https://github.com/rootlyhq/rootly/pull/17564) ([OC-4124](https://linear.app/rootly/issue/OC-4124)).

The first three are already declared in the latest swagger; the alert_group widening is ahead of the swagger and depends on rootlyhq/rootly#17564 landing first. Behavior on the customer side is gated by Flipper, so this PR is safe to merge once that monolith PR ships.

## Why this shape

I ran `make codegen` against the latest swagger and the generated diff touched ~290 files. Most of it was unrelated codegen drift (import re-orders, new resources for unrelated API additions, etc). I cherry-picked only the user-visible paging-functionality additions and reverted everything else, following the precedent set by #178 (small targeted hand-edit to the three "DO NOT MODIFY" files for the affected resource).

## Breaking change risk

None — all changes are strictly additive:

| Change | Risk |
|---|---|
| `escalation_policy_id` on functionality (Optional+Computed) | Existing plans omitting it keep working. If the API now returns a value for a functionality created via UI, `terraform plan` shows a one-time refresh-time set, no destroy/recreate. |
| `Functionality` added to `alert_routing_rule.target_type` enum | Pure widening of an allow-list. Existing values remain valid. |
| `Functionality` added to `heartbeat.notification_target_type` enum | Pure widening. |
| `Functionality` added to `alert_group.targets[].target_type` enum | Pure widening. |

## Test plan

- [x] `go build` clean
- [x] `terraform validate` passes against a config exercising all four new attributes
- [x] Negative test: invalid target_type still rejected with the new four-value list shown
- [ ] `terraform apply` round-trip against local Rootly (Flipper flag enabled) for each of the four
- [ ] In-place update of `escalation_policy_id` works
- [ ] Removing `escalation_policy_id` and applying clears the association

## Merge order

1. Land [rootlyhq/rootly#17564](https://github.com/rootlyhq/rootly/pull/17564) so the swagger declares Functionality on alert_group targets.
2. Mark this PR ready for review and merge.