### PR TITLE
Add integration field to Jira and Confluence workflow tasks

### DIFF
--- a/docs/resources/workflow_task_update_confluence_page.md
+++ b/docs/resources/workflow_task_update_confluence_page.md
@@ -40,6 +40,7 @@ Required:
 Optional:
 
 - `content` (String) The Confluence page content
+- `integration` (Map of String) Map must contain two fields, `id` and `name`. Specify integration id if you have more than one Confluence instance
 - `post_mortem_template_id` (String) Retrospective template to use when updating page, if desired
 - `task_type` (String)
 - `template` (Map of String) Map must contain two fields, `id` and `name`. The Confluence template to use

--- a/docs/resources/workflow_task_update_jira_issue.md
+++ b/docs/resources/workflow_task_update_jira_issue.md
@@ -44,6 +44,7 @@ Optional:
 - `custom_fields_mapping` (String) Custom field mappings. Can contain liquid markup and need to be valid JSON
 - `description` (String) The issue description
 - `due_date` (String) The due date
+- `integration` (Map of String) Map must contain two fields, `id` and `name`. Specify integration id if you have more than one Jira instance
 - `labels` (String) The issue labels
 - `priority` (Map of String) Map must contain two fields, `id` and `name`. The priority id and display name
 - `reporter_user_email` (String) The reporter user's email

--- a/provider/resource_workflow_task_update_confluence_page.go
+++ b/provider/resource_workflow_task_update_confluence_page.go
@@ -75,6 +75,11 @@ func resourceWorkflowTaskUpdateConfluencePage() *schema.Resource {
 								"update_confluence_page",
 							}, false),
 						},
+						"integration": &schema.Schema{
+							Description: "Map must contain two fields, `id` and `name`. Specify integration id if you have more than one Confluence instance",
+							Type:        schema.TypeMap,
+							Optional:    true,
+						},
 						"file_id": &schema.Schema{
 							Description: "The Confluence page ID",
 							Type:        schema.TypeString,

--- a/provider/resource_workflow_task_update_jira_issue.go
+++ b/provider/resource_workflow_task_update_jira_issue.go
@@ -77,6 +77,11 @@ func resourceWorkflowTaskUpdateJiraIssue() *schema.Resource {
 								"update_jira_issue",
 							}, false),
 						},
+						"integration": &schema.Schema{
+							Description: "Map must contain two fields, `id` and `name`. Specify integration id if you have more than one Jira instance",
+							Type:        schema.TypeMap,
+							Optional:    true,
+						},
 						"issue_id": &schema.Schema{
 							Description: "The issue id",
 							Type:        schema.TypeString,


### PR DESCRIPTION
## Summary

- Regenerate provider from latest OpenAPI schema
- Adds `integration` field to `update_jira_issue` and `update_confluence_page` workflow tasks
- Allows specifying which integration to use when multiple Jira/Confluence instances are connected
- Field was added to the API schema to replace the previously hand-patched version removed in #262

## Test plan

- [x] `go build` succeeds
- [ ] CI acceptance tests