### PR TITLE
Fix data source codegen to persist parent ID in state

### DIFF
--- a/provider/data_source_alert_field.go
+++ b/provider/data_source_alert_field.go
@@ -81,6 +81,7 @@ func dataSourceAlertFieldRead(ctx context.Context, d *schema.ResourceData, meta 
 	item, _ := items[0].(*client.AlertField)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("kind", item.Kind)
 	return nil

--- a/provider/data_source_alert_routing_rule.go
+++ b/provider/data_source_alert_routing_rule.go
@@ -70,6 +70,7 @@ func dataSourceAlertRoutingRuleRead(ctx context.Context, d *schema.ResourceData,
 	item, _ := items[0].(*client.AlertRoutingRule)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	return nil
 }

--- a/provider/data_source_alert_urgency.go
+++ b/provider/data_source_alert_urgency.go
@@ -70,6 +70,7 @@ func dataSourceAlertUrgencyRead(ctx context.Context, d *schema.ResourceData, met
 	item, _ := items[0].(*client.AlertUrgency)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	return nil
 }

--- a/provider/data_source_api_key.go
+++ b/provider/data_source_api_key.go
@@ -130,6 +130,7 @@ func dataSourceApiKeyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	item, _ := items[0].(*client.ApiKey)
 
 	d.SetId(item.ID)
+
 	d.Set("kind", item.Kind)
 	d.Set("name", item.Name)
 	d.Set("role_id", item.RoleId)

--- a/provider/data_source_authorization.go
+++ b/provider/data_source_authorization.go
@@ -106,6 +106,7 @@ func dataSourceAuthorizationRead(ctx context.Context, d *schema.ResourceData, me
 	item, _ := items[0].(*client.Authorization)
 
 	d.SetId(item.ID)
+
 	d.Set("authorizable_id", item.AuthorizableId)
 	d.Set("authorizable_type", item.AuthorizableType)
 	d.Set("grantee_id", item.GranteeId)

--- a/provider/data_source_catalog_checklist_template.go
+++ b/provider/data_source_catalog_checklist_template.go
@@ -106,6 +106,7 @@ func dataSourceCatalogChecklistTemplateRead(ctx context.Context, d *schema.Resou
 	item, _ := items[0].(*client.CatalogChecklistTemplate)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("catalog_type", item.CatalogType)

--- a/provider/data_source_cause.go
+++ b/provider/data_source_cause.go
@@ -81,6 +81,7 @@ func dataSourceCauseRead(ctx context.Context, d *schema.ResourceData, meta inter
 	item, _ := items[0].(*client.Cause)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	return nil

--- a/provider/data_source_communications_stage.go
+++ b/provider/data_source_communications_stage.go
@@ -81,6 +81,7 @@ func dataSourceCommunicationsStageRead(ctx context.Context, d *schema.ResourceDa
 	item, _ := items[0].(*client.CommunicationsStage)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	return nil

--- a/provider/data_source_communications_template.go
+++ b/provider/data_source_communications_template.go
@@ -98,6 +98,7 @@ func dataSourceCommunicationsTemplateRead(ctx context.Context, d *schema.Resourc
 	item, _ := items[0].(*client.CommunicationsTemplate)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("communication_type_id", item.CommunicationTypeId)

--- a/provider/data_source_communications_type.go
+++ b/provider/data_source_communications_type.go
@@ -81,6 +81,7 @@ func dataSourceCommunicationsTypeRead(ctx context.Context, d *schema.ResourceDat
 	item, _ := items[0].(*client.CommunicationsType)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	return nil

--- a/provider/data_source_custom_form.go
+++ b/provider/data_source_custom_form.go
@@ -92,6 +92,7 @@ func dataSourceCustomFormRead(ctx context.Context, d *schema.ResourceData, meta 
 	item, _ := items[0].(*client.CustomForm)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("command", item.Command)

--- a/provider/data_source_environment.go
+++ b/provider/data_source_environment.go
@@ -92,6 +92,7 @@ func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 	item, _ := items[0].(*client.Environment)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("color", item.Color)

--- a/provider/data_source_escalation_policy.go
+++ b/provider/data_source_escalation_policy.go
@@ -70,6 +70,7 @@ func dataSourceEscalationPolicyRead(ctx context.Context, d *schema.ResourceData,
 	item, _ := items[0].(*client.EscalationPolicy)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	return nil
 }

--- a/provider/data_source_form_field.go
+++ b/provider/data_source_form_field.go
@@ -105,6 +105,7 @@ func dataSourceFormFieldRead(ctx context.Context, d *schema.ResourceData, meta i
 	item, _ := items[0].(*client.FormField)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("kind", item.Kind)

--- a/provider/data_source_form_field_option.go
+++ b/provider/data_source_form_field_option.go
@@ -69,6 +69,7 @@ func dataSourceFormFieldOptionRead(ctx context.Context, d *schema.ResourceData, 
 	item, _ := items[0].(*client.FormFieldOption)
 
 	d.SetId(item.ID)
+	d.Set("form_field_id", form_field_id)
 	d.Set("value", item.Value)
 	d.Set("color", item.Color)
 	return nil

--- a/provider/data_source_form_field_placement.go
+++ b/provider/data_source_form_field_placement.go
@@ -58,6 +58,7 @@ func dataSourceFormFieldPlacementRead(ctx context.Context, d *schema.ResourceDat
 	item, _ := items[0].(*client.FormFieldPlacement)
 
 	d.SetId(item.ID)
-	d.Set("form_field_id", item.FormFieldId)
+	d.Set("form_field_id", form_field_id)
+
 	return nil
 }

--- a/provider/data_source_form_field_placement_condition.go
+++ b/provider/data_source_form_field_placement_condition.go
@@ -58,6 +58,7 @@ func dataSourceFormFieldPlacementConditionRead(ctx context.Context, d *schema.Re
 	item, _ := items[0].(*client.FormFieldPlacementCondition)
 
 	d.SetId(item.ID)
+	d.Set("form_field_placement_id", form_field_placement_id)
 	d.Set("form_field_id", item.FormFieldId)
 	return nil
 }

--- a/provider/data_source_form_field_position.go
+++ b/provider/data_source_form_field_position.go
@@ -60,6 +60,7 @@ func dataSourceFormFieldPositionRead(ctx context.Context, d *schema.ResourceData
 	item, _ := items[0].(*client.FormFieldPosition)
 
 	d.SetId(item.ID)
+	d.Set("form_field_id", form_field_id)
 	d.Set("form", item.Form)
 	return nil
 }

--- a/provider/data_source_form_set.go
+++ b/provider/data_source_form_set.go
@@ -81,6 +81,7 @@ func dataSourceFormSetRead(ctx context.Context, d *schema.ResourceData, meta int
 	item, _ := items[0].(*client.FormSet)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	return nil
 }

--- a/provider/data_source_form_set_condition.go
+++ b/provider/data_source_form_set_condition.go
@@ -58,6 +58,7 @@ func dataSourceFormSetConditionRead(ctx context.Context, d *schema.ResourceData,
 	item, _ := items[0].(*client.FormSetCondition)
 
 	d.SetId(item.ID)
+	d.Set("form_set_id", form_set_id)
 	d.Set("form_field_id", item.FormFieldId)
 	return nil
 }

--- a/provider/data_source_functionality.go
+++ b/provider/data_source_functionality.go
@@ -114,6 +114,7 @@ func dataSourceFunctionalityRead(ctx context.Context, d *schema.ResourceData, me
 	item, _ := items[0].(*client.Functionality)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("backstage_id", item.BackstageId)
 	d.Set("cortex_id", item.CortexId)

--- a/provider/data_source_heartbeat.go
+++ b/provider/data_source_heartbeat.go
@@ -70,6 +70,7 @@ func dataSourceHeartbeatRead(ctx context.Context, d *schema.ResourceData, meta i
 	item, _ := items[0].(*client.Heartbeat)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	return nil
 }

--- a/provider/data_source_incident_permission_set.go
+++ b/provider/data_source_incident_permission_set.go
@@ -81,6 +81,7 @@ func dataSourceIncidentPermissionSetRead(ctx context.Context, d *schema.Resource
 	item, _ := items[0].(*client.IncidentPermissionSet)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	return nil

--- a/provider/data_source_incident_permission_set_boolean.go
+++ b/provider/data_source_incident_permission_set_boolean.go
@@ -78,6 +78,7 @@ func dataSourceIncidentPermissionSetBooleanRead(ctx context.Context, d *schema.R
 	item, _ := items[0].(*client.IncidentPermissionSetBoolean)
 
 	d.SetId(item.ID)
+	d.Set("incident_permission_set_id", incident_permission_set_id)
 	d.Set("kind", item.Kind)
 	return nil
 }

--- a/provider/data_source_incident_permission_set_resource.go
+++ b/provider/data_source_incident_permission_set_resource.go
@@ -78,6 +78,7 @@ func dataSourceIncidentPermissionSetResourceRead(ctx context.Context, d *schema.
 	item, _ := items[0].(*client.IncidentPermissionSetResource)
 
 	d.SetId(item.ID)
+	d.Set("incident_permission_set_id", incident_permission_set_id)
 	d.Set("kind", item.Kind)
 	return nil
 }

--- a/provider/data_source_incident_post_mortem.go
+++ b/provider/data_source_incident_post_mortem.go
@@ -126,6 +126,7 @@ func dataSourceIncidentPostMortemRead(ctx context.Context, d *schema.ResourceDat
 	item, _ := items[0].(*client.IncidentPostMortem)
 
 	d.SetId(item.ID)
+
 	d.Set("status", item.Status)
 	return nil
 }

--- a/provider/data_source_incident_role.go
+++ b/provider/data_source_incident_role.go
@@ -92,6 +92,7 @@ func dataSourceIncidentRoleRead(ctx context.Context, d *schema.ResourceData, met
 	item, _ := items[0].(*client.IncidentRole)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("enabled", item.Enabled)

--- a/provider/data_source_incident_sub_status.go
+++ b/provider/data_source_incident_sub_status.go
@@ -76,6 +76,7 @@ func dataSourceIncidentSubStatusRead(ctx context.Context, d *schema.ResourceData
 	item, _ := items[0].(*client.IncidentSubStatus)
 
 	d.SetId(item.ID)
+	d.Set("incident_id", incident_id)
 	d.Set("sub_status_id", item.SubStatusId)
 	return nil
 }

--- a/provider/data_source_incident_type.go
+++ b/provider/data_source_incident_type.go
@@ -92,6 +92,7 @@ func dataSourceIncidentTypeRead(ctx context.Context, d *schema.ResourceData, met
 	item, _ := items[0].(*client.IncidentType)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("color", item.Color)

--- a/provider/data_source_live_call_router.go
+++ b/provider/data_source_live_call_router.go
@@ -70,6 +70,7 @@ func dataSourceLiveCallRouterRead(ctx context.Context, d *schema.ResourceData, m
 	item, _ := items[0].(*client.LiveCallRouter)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	return nil
 }

--- a/provider/data_source_on_call_role.go
+++ b/provider/data_source_on_call_role.go
@@ -81,6 +81,7 @@ func dataSourceOnCallRoleRead(ctx context.Context, d *schema.ResourceData, meta 
 	item, _ := items[0].(*client.OnCallRole)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	return nil

--- a/provider/data_source_retrospective_process_group.go
+++ b/provider/data_source_retrospective_process_group.go
@@ -70,6 +70,7 @@ func dataSourceRetrospectiveProcessGroupRead(ctx context.Context, d *schema.Reso
 	item, _ := items[0].(*client.RetrospectiveProcessGroup)
 
 	d.SetId(item.ID)
+	d.Set("retrospective_process_id", retrospective_process_id)
 	d.Set("sub_status_id", item.SubStatusId)
 	return nil
 }

--- a/provider/data_source_retrospective_process_group_step.go
+++ b/provider/data_source_retrospective_process_group_step.go
@@ -70,6 +70,7 @@ func dataSourceRetrospectiveProcessGroupStepRead(ctx context.Context, d *schema.
 	item, _ := items[0].(*client.RetrospectiveProcessGroupStep)
 
 	d.SetId(item.ID)
+	d.Set("retrospective_process_group_id", retrospective_process_group_id)
 	d.Set("retrospective_step_id", item.RetrospectiveStepId)
 	return nil
 }

--- a/provider/data_source_role.go
+++ b/provider/data_source_role.go
@@ -81,6 +81,7 @@ func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interf
 	item, _ := items[0].(*client.Role)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	return nil

--- a/provider/data_source_service.go
+++ b/provider/data_source_service.go
@@ -136,6 +136,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 	item, _ := items[0].(*client.Service)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("backstage_id", item.BackstageId)

--- a/provider/data_source_severity.go
+++ b/provider/data_source_severity.go
@@ -105,6 +105,7 @@ func dataSourceSeverityRead(ctx context.Context, d *schema.ResourceData, meta in
 	item, _ := items[0].(*client.Severity)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("severity", item.Severity)

--- a/provider/data_source_status_page.go
+++ b/provider/data_source_status_page.go
@@ -70,6 +70,7 @@ func dataSourceStatusPageRead(ctx context.Context, d *schema.ResourceData, meta 
 	item, _ := items[0].(*client.StatusPage)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	return nil
 }

--- a/provider/data_source_sub_status.go
+++ b/provider/data_source_sub_status.go
@@ -94,6 +94,7 @@ func dataSourceSubStatusRead(ctx context.Context, d *schema.ResourceData, meta i
 	item, _ := items[0].(*client.SubStatus)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("parent_status", item.ParentStatus)

--- a/provider/data_source_team.go
+++ b/provider/data_source_team.go
@@ -147,6 +147,7 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 	item, _ := items[0].(*client.Team)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	d.Set("backstage_id", item.BackstageId)

--- a/provider/data_source_user.go
+++ b/provider/data_source_user.go
@@ -70,6 +70,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	item, _ := items[0].(*client.User)
 
 	d.SetId(item.ID)
+
 	d.Set("email", item.Email)
 	return nil
 }

--- a/provider/data_source_webhooks_endpoint.go
+++ b/provider/data_source_webhooks_endpoint.go
@@ -63,6 +63,7 @@ func dataSourceWebhooksEndpointRead(ctx context.Context, d *schema.ResourceData,
 	item, _ := items[0].(*client.WebhooksEndpoint)
 
 	d.SetId(item.ID)
+
 	d.Set("slug", item.Slug)
 	d.Set("name", item.Name)
 	return nil

--- a/provider/data_source_workflow.go
+++ b/provider/data_source_workflow.go
@@ -81,6 +81,7 @@ func dataSourceWorkflowRead(ctx context.Context, d *schema.ResourceData, meta in
 	item, _ := items[0].(*client.Workflow)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	return nil

--- a/provider/data_source_workflow_group.go
+++ b/provider/data_source_workflow_group.go
@@ -98,6 +98,7 @@ func dataSourceWorkflowGroupRead(ctx context.Context, d *schema.ResourceData, me
 	item, _ := items[0].(*client.WorkflowGroup)
 
 	d.SetId(item.ID)
+
 	d.Set("name", item.Name)
 	d.Set("slug", item.Slug)
 	d.Set("kind", item.Kind)

--- a/tools/generate-data-source-tpl.js
+++ b/tools/generate-data-source-tpl.js
@@ -60,7 +60,8 @@ func dataSource${nameCamel}Read(ctx context.Context, d *schema.ResourceData, met
 	item, _ := items[0].(*client.${nameCamel})
 
 	d.SetId(item.ID)
-	${setOutputFields(resourceSchema, filterParameters)}
+	${pathIdField ? `d.Set("${pathIdField}", ${pathIdField})` : ''}
+	${setOutputFields(resourceSchema, filterParameters, pathIdField)}
 	return nil
 }
 `;
@@ -154,7 +155,7 @@ function setFilterFields(name, resourceSchema, filterParameters) {
     .join("\n");
 }
 
-function setOutputFields(resourceSchema, filterParameters) {
+function setOutputFields(resourceSchema, filterParameters, pathIdField) {
   // Generate d.Set() calls for filter fields so they're available in Terraform state
   return (filterParameters || [])
     .filter((paramSchema) => {
@@ -162,6 +163,8 @@ function setOutputFields(resourceSchema, filterParameters) {
     })
     .map((paramSchema) => {
       const filterField = filterUnderscore(paramSchema.name);
+      // Skip pathIdField — already set from the local variable above
+      if (pathIdField && filterField === pathIdField) return;
       // Try to find the field in the schema, checking both plural and singular forms
       let fieldSchema = resourceSchema.properties[filterField];
       let schemaFieldName = filterField;


### PR DESCRIPTION
## Summary
- Data source template (`generate-data-source-tpl.js`) used `pathIdField` (e.g. `form_field_id`) for API calls but never persisted it to Terraform state via `d.Set()`
- This made `rootly_form_field_option` data source unusable — `form_field_id` was required but never stored after read
- Added `d.Set()` for pathIdField in template, and skip duplicate output when pathIdField overlaps with filter fields
- Regenerated all affected data sources

Fixes #123

## Test plan
- [ ] `data "rootly_form_field_option"` with `form_field_id` should work without errors
- [ ] `form_field_id` should be available in state after data source read
- [ ] Verify no duplicate `d.Set` calls in generated data sources with parent IDs