### PR TITLE
Make owner_user_id required on rootly_schedule

### DIFF
--- a/provider/resource_schedule.go
+++ b/provider/resource_schedule.go
@@ -92,9 +92,11 @@ func resourceSchedule() *schema.Resource {
 
 			"owner_user_id": &schema.Schema{
 				Type:        schema.TypeInt,
-				Required:    true,
+				Computed:    true,
+				Required:    false,
+				Optional:    true,
 				ForceNew:    false,
-				Description: "ID of user assigned as owner of the schedule",
+				Description: "ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.",
 			},
 		},
 	}

--- a/provider/resource_schedule.go
+++ b/provider/resource_schedule.go
@@ -92,9 +92,7 @@ func resourceSchedule() *schema.Resource {
 
 			"owner_user_id": &schema.Schema{
 				Type:        schema.TypeInt,
-				Computed:    true,
-				Required:    false,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    false,
 				Description: "ID of user assigned as owner of the schedule",
 			},


### PR DESCRIPTION
## Summary
- `owner_user_id` was marked as `Optional + Computed` but the Rootly UI requires it
- When omitted, the API silently assigns the API token's user as owner — unexpected behavior
- Changed to `Required: true` to match UI behavior and give users a clear error at plan time

**Note:** This is a minor breaking change for users who relied on the auto-assignment. They'll need to add `owner_user_id` to their config on next plan.

Fixes #99

## Test plan
- [ ] `rootly_schedule` without `owner_user_id` should fail validation at plan time
- [ ] `rootly_schedule` with `owner_user_id` should work as before