### PR TITLE
chore: align module path with SemVer tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Workflow tasks are special resources with dynamic generation based on OpenAPI sc
 ### Terraform Schema Flags
 The provider uses custom OpenAPI schema annotations to control Terraform resource generation behavior. These flags are processed in the JavaScript template files during code generation:
 
-- **`tf_diff_suppress_func`** - A custom diff suppressor function. Diff functions should be implemented in the `github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc` package.
+- **`tf_diff_suppress_func`** - A custom diff suppressor function. Diff functions should be implemented in the `github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc` package.
 - **`tf_skip_diff`** - Prevents Terraform from detecting differences on a field. Adds a `DiffSuppressFunc` that suppresses diffs when an old value exists. Used for sensitive fields like secrets or computed status fields. Deprecated. Use `tf_diff_suppress_func` instead with `diffsuppressfunc.Skip`.
 - **`tf_sensitive`** - Ensures that the attribute's value does not get displayed in logs or regular output.
 - **`tf_force_new`** - Indicates that any change in this field requires the resource to be destroyed and recreated.

--- a/client/alert_fields.go
+++ b/client/alert_fields.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertField struct {

--- a/client/alert_groups.go
+++ b/client/alert_groups.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertGroup struct {

--- a/client/alert_routes.go
+++ b/client/alert_routes.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertRoute struct {

--- a/client/alert_routing_rules.go
+++ b/client/alert_routing_rules.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertRoutingRule struct {

--- a/client/alert_urgencies.go
+++ b/client/alert_urgencies.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertUrgency struct {

--- a/client/alerts_sources.go
+++ b/client/alerts_sources.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type AlertsSource struct {

--- a/client/api_keys.go
+++ b/client/api_keys.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ApiKey struct {

--- a/client/audits.go
+++ b/client/audits.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Audit struct {

--- a/client/authorizations.go
+++ b/client/authorizations.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Authorization struct {

--- a/client/catalog_checklist_templates.go
+++ b/client/catalog_checklist_templates.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CatalogChecklistTemplate struct {

--- a/client/catalog_entities.go
+++ b/client/catalog_entities.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CatalogEntity struct {

--- a/client/catalog_properties.go
+++ b/client/catalog_properties.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CatalogProperty struct {

--- a/client/catalogs.go
+++ b/client/catalogs.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Catalog struct {

--- a/client/causes.go
+++ b/client/causes.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Cause struct {

--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Client struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-cleanhttp"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type requestTesterFunc func(r *http.Request) error

--- a/client/communications_groups.go
+++ b/client/communications_groups.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CommunicationsGroup struct {

--- a/client/communications_stages.go
+++ b/client/communications_stages.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CommunicationsStage struct {

--- a/client/communications_templates.go
+++ b/client/communications_templates.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CommunicationsTemplate struct {

--- a/client/communications_types.go
+++ b/client/communications_types.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CommunicationsType struct {

--- a/client/custom_field_options.go
+++ b/client/custom_field_options.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CustomFieldOption struct {

--- a/client/custom_fields.go
+++ b/client/custom_fields.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CustomField struct {

--- a/client/custom_forms.go
+++ b/client/custom_forms.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type CustomForm struct {

--- a/client/dashboard_panels.go
+++ b/client/dashboard_panels.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type DashboardPanel struct {

--- a/client/dashboards.go
+++ b/client/dashboards.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Dashboard struct {

--- a/client/edge_connector_actions.go
+++ b/client/edge_connector_actions.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type EdgeConnectorAction struct {

--- a/client/edge_connectors.go
+++ b/client/edge_connectors.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type EdgeConnector struct {

--- a/client/environments.go
+++ b/client/environments.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Environment struct {

--- a/client/escalation_levels.go
+++ b/client/escalation_levels.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type EscalationLevel struct {

--- a/client/escalation_paths.go
+++ b/client/escalation_paths.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type EscalationPath struct {

--- a/client/escalation_policies.go
+++ b/client/escalation_policies.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type EscalationPolicy struct {

--- a/client/form_field_options.go
+++ b/client/form_field_options.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormFieldOption struct {

--- a/client/form_field_placement_conditions.go
+++ b/client/form_field_placement_conditions.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormFieldPlacementCondition struct {

--- a/client/form_field_placements.go
+++ b/client/form_field_placements.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormFieldPlacement struct {

--- a/client/form_field_positions.go
+++ b/client/form_field_positions.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormFieldPosition struct {

--- a/client/form_fields.go
+++ b/client/form_fields.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormField struct {

--- a/client/form_set_conditions.go
+++ b/client/form_set_conditions.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormSetCondition struct {

--- a/client/form_sets.go
+++ b/client/form_sets.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type FormSet struct {

--- a/client/functionalities.go
+++ b/client/functionalities.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Functionality struct {

--- a/client/heartbeats.go
+++ b/client/heartbeats.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Heartbeat struct {

--- a/client/incident_form_field_selections.go
+++ b/client/incident_form_field_selections.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentFormFieldSelection struct {

--- a/client/incident_permission_set_booleans.go
+++ b/client/incident_permission_set_booleans.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentPermissionSetBoolean struct {

--- a/client/incident_permission_set_resources.go
+++ b/client/incident_permission_set_resources.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentPermissionSetResource struct {

--- a/client/incident_permission_sets.go
+++ b/client/incident_permission_sets.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentPermissionSet struct {

--- a/client/incident_post_mortems.go
+++ b/client/incident_post_mortems.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentPostMortem struct {

--- a/client/incident_role_tasks.go
+++ b/client/incident_role_tasks.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentRoleTask struct {

--- a/client/incident_roles.go
+++ b/client/incident_roles.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentRole struct {

--- a/client/incident_sub_statuses.go
+++ b/client/incident_sub_statuses.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentSubStatus struct {

--- a/client/incident_types.go
+++ b/client/incident_types.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IncidentType struct {

--- a/client/incidents.go
+++ b/client/incidents.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Incident struct {

--- a/client/ip_ranges.go
+++ b/client/ip_ranges.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type IpRanges struct {

--- a/client/live_call_routers.go
+++ b/client/live_call_routers.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type LiveCallRouter struct {

--- a/client/on_call_roles.go
+++ b/client/on_call_roles.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type OnCallRole struct {

--- a/client/on_call_shadows.go
+++ b/client/on_call_shadows.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type OnCallShadow struct {

--- a/client/override_shifts.go
+++ b/client/override_shifts.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type OverrideShift struct {

--- a/client/playbook_tasks.go
+++ b/client/playbook_tasks.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type PlaybookTask struct {

--- a/client/playbooks.go
+++ b/client/playbooks.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Playbook struct {

--- a/client/post_mortem_templates.go
+++ b/client/post_mortem_templates.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type PostmortemTemplate struct {

--- a/client/retrospective_configurations.go
+++ b/client/retrospective_configurations.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RetrospectiveConfiguration struct {

--- a/client/retrospective_process_group_steps.go
+++ b/client/retrospective_process_group_steps.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RetrospectiveProcessGroupStep struct {

--- a/client/retrospective_process_groups.go
+++ b/client/retrospective_process_groups.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RetrospectiveProcessGroup struct {

--- a/client/retrospective_processes.go
+++ b/client/retrospective_processes.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RetrospectiveProcess struct {

--- a/client/retrospective_steps.go
+++ b/client/retrospective_steps.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RetrospectiveStep struct {

--- a/client/roles.go
+++ b/client/roles.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Role struct {

--- a/client/schedule_rotation_active_days.go
+++ b/client/schedule_rotation_active_days.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ScheduleRotationActiveDay struct {

--- a/client/schedule_rotation_users.go
+++ b/client/schedule_rotation_users.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ScheduleRotationUser struct {

--- a/client/schedule_rotations.go
+++ b/client/schedule_rotations.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ScheduleRotation struct {

--- a/client/schedules.go
+++ b/client/schedules.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Schedule struct {

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Secret struct {

--- a/client/services.go
+++ b/client/services.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Service struct {

--- a/client/severities.go
+++ b/client/severities.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Severity struct {

--- a/client/slas.go
+++ b/client/slas.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type SLA struct {

--- a/client/status_page_templates.go
+++ b/client/status_page_templates.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type StatusPageTemplate struct {

--- a/client/status_pages.go
+++ b/client/status_pages.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type StatusPage struct {

--- a/client/sub_statuses.go
+++ b/client/sub_statuses.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type SubStatus struct {

--- a/client/teams.go
+++ b/client/teams.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Team struct {

--- a/client/users.go
+++ b/client/users.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type User struct {

--- a/client/webhooks_endpoints.go
+++ b/client/webhooks_endpoints.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type WebhooksEndpoint struct {

--- a/client/workflow_custom_field_selections.go
+++ b/client/workflow_custom_field_selections.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type WorkflowCustomFieldSelection struct {

--- a/client/workflow_form_field_conditions.go
+++ b/client/workflow_form_field_conditions.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type WorkflowFormFieldCondition struct {

--- a/client/workflow_groups.go
+++ b/client/workflow_groups.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type WorkflowGroup struct {

--- a/client/workflow_tasks.go
+++ b/client/workflow_tasks.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type WorkflowTask struct {

--- a/client/workflows.go
+++ b/client/workflows.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type Workflow struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rootlyhq/terraform-provider-rootly/v2
+module github.com/rootlyhq/terraform-provider-rootly/v5
 
 go 1.25.8
 

--- a/internal/acctest/shared_client.go
+++ b/internal/acctest/shared_client.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/apiclient"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/meta"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/apiclient"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/meta"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 var (

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -3,9 +3,9 @@ package apiclient
 import (
 	"fmt"
 
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v2/provider"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v5/provider"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func New(apiHost string, apiToken string, version string) (*client.Client, *rootly.ClientWithResponses, error) {

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type baseDataSource struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/apiclient"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/apiclient"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type RootlyProviderModel struct {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/meta"
-	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v2/provider"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/meta"
+	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v5/provider"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type baseResource struct {

--- a/internal/provider/resource_alert_route_test.go
+++ b/internal/provider/resource_alert_route_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_alert_urgency_test.go
+++ b/internal/provider/resource_alert_urgency_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_alerts_source_test.go
+++ b/internal/provider/resource_alerts_source_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_dashboard_panel_test.go
+++ b/internal/provider/resource_dashboard_panel_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
 )
 
 func TestAccResourceDashboardPanel(t *testing.T) {

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_escalation_policy_test.go
+++ b/internal/provider/resource_escalation_policy_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_override_shift_test.go
+++ b/internal/provider/resource_override_shift_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/must"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
 )
 
 func TestAccResourceOverrideShift(t *testing.T) {

--- a/internal/provider/resource_role_test.go
+++ b/internal/provider/resource_role_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/go-utils/ptr"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/acctest"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/acctest"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -5,15 +5,15 @@ import (
 	"flag"
 	"log"
 
-	"github.com/rootlyhq/terraform-provider-rootly/v2/meta"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/meta"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
-	framework_provider "github.com/rootlyhq/terraform-provider-rootly/v2/internal/provider"
-	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v2/provider"
+	framework_provider "github.com/rootlyhq/terraform-provider-rootly/v5/internal/provider"
+	sdkv2_provider "github.com/rootlyhq/terraform-provider-rootly/v5/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website

--- a/provider/data_source_alert_field.go
+++ b/provider/data_source_alert_field.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAlertField() *schema.Resource {

--- a/provider/data_source_alert_route.go
+++ b/provider/data_source_alert_route.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAlertRoute() *schema.Resource {

--- a/provider/data_source_alert_routing_rule.go
+++ b/provider/data_source_alert_routing_rule.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAlertRoutingRule() *schema.Resource {

--- a/provider/data_source_alert_urgency.go
+++ b/provider/data_source_alert_urgency.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAlertUrgency() *schema.Resource {

--- a/provider/data_source_alerts_source.go
+++ b/provider/data_source_alerts_source.go
@@ -6,9 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/polling"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/polling"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAlertsSource() *schema.Resource {

--- a/provider/data_source_api_key.go
+++ b/provider/data_source_api_key.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceApiKey() *schema.Resource {

--- a/provider/data_source_authorization.go
+++ b/provider/data_source_authorization.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceAuthorization() *schema.Resource {

--- a/provider/data_source_catalog.go
+++ b/provider/data_source_catalog.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/polling"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/polling"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCatalog() *schema.Resource {

--- a/provider/data_source_catalog_checklist_template.go
+++ b/provider/data_source_catalog_checklist_template.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCatalogChecklistTemplate() *schema.Resource {

--- a/provider/data_source_catalog_entity.go
+++ b/provider/data_source_catalog_entity.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/polling"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/polling"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCatalogEntity() *schema.Resource {

--- a/provider/data_source_cause.go
+++ b/provider/data_source_cause.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCause() *schema.Resource {

--- a/provider/data_source_causes.go
+++ b/provider/data_source_causes.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCauses() *schema.Resource {

--- a/provider/data_source_communications_group.go
+++ b/provider/data_source_communications_group.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCommunicationsGroup() *schema.Resource {

--- a/provider/data_source_communications_stage.go
+++ b/provider/data_source_communications_stage.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCommunicationsStage() *schema.Resource {

--- a/provider/data_source_communications_template.go
+++ b/provider/data_source_communications_template.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCommunicationsTemplate() *schema.Resource {

--- a/provider/data_source_communications_type.go
+++ b/provider/data_source_communications_type.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCommunicationsType() *schema.Resource {

--- a/provider/data_source_custom_field.go
+++ b/provider/data_source_custom_field.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCustomField() *schema.Resource {

--- a/provider/data_source_custom_field_option.go
+++ b/provider/data_source_custom_field_option.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCustomFieldOption() *schema.Resource {

--- a/provider/data_source_custom_field_options.go
+++ b/provider/data_source_custom_field_options.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCustomFieldOptions() *schema.Resource {

--- a/provider/data_source_custom_fields.go
+++ b/provider/data_source_custom_fields.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCustomFields() *schema.Resource {

--- a/provider/data_source_custom_form.go
+++ b/provider/data_source_custom_form.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceCustomForm() *schema.Resource {

--- a/provider/data_source_environment.go
+++ b/provider/data_source_environment.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceEnvironment() *schema.Resource {

--- a/provider/data_source_environments.go
+++ b/provider/data_source_environments.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceEnvironments() *schema.Resource {

--- a/provider/data_source_escalation_policy.go
+++ b/provider/data_source_escalation_policy.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceEscalationPolicy() *schema.Resource {

--- a/provider/data_source_form_field.go
+++ b/provider/data_source_form_field.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormField() *schema.Resource {

--- a/provider/data_source_form_field_option.go
+++ b/provider/data_source_form_field_option.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormFieldOption() *schema.Resource {

--- a/provider/data_source_form_field_placement.go
+++ b/provider/data_source_form_field_placement.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormFieldPlacement() *schema.Resource {

--- a/provider/data_source_form_field_placement_condition.go
+++ b/provider/data_source_form_field_placement_condition.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormFieldPlacementCondition() *schema.Resource {

--- a/provider/data_source_form_field_position.go
+++ b/provider/data_source_form_field_position.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormFieldPosition() *schema.Resource {

--- a/provider/data_source_form_set.go
+++ b/provider/data_source_form_set.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormSet() *schema.Resource {

--- a/provider/data_source_form_set_condition.go
+++ b/provider/data_source_form_set_condition.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFormSetCondition() *schema.Resource {

--- a/provider/data_source_functionalities.go
+++ b/provider/data_source_functionalities.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFunctionalities() *schema.Resource {

--- a/provider/data_source_functionality.go
+++ b/provider/data_source_functionality.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceFunctionality() *schema.Resource {

--- a/provider/data_source_heartbeat.go
+++ b/provider/data_source_heartbeat.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceHeartbeat() *schema.Resource {

--- a/provider/data_source_incident.go
+++ b/provider/data_source_incident.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncident() *schema.Resource {

--- a/provider/data_source_incident_permission_set.go
+++ b/provider/data_source_incident_permission_set.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentPermissionSet() *schema.Resource {

--- a/provider/data_source_incident_permission_set_boolean.go
+++ b/provider/data_source_incident_permission_set_boolean.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentPermissionSetBoolean() *schema.Resource {

--- a/provider/data_source_incident_permission_set_resource.go
+++ b/provider/data_source_incident_permission_set_resource.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentPermissionSetResource() *schema.Resource {

--- a/provider/data_source_incident_post_mortem.go
+++ b/provider/data_source_incident_post_mortem.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentPostMortem() *schema.Resource {

--- a/provider/data_source_incident_role.go
+++ b/provider/data_source_incident_role.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentRole() *schema.Resource {

--- a/provider/data_source_incident_roles.go
+++ b/provider/data_source_incident_roles.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentRoles() *schema.Resource {

--- a/provider/data_source_incident_sub_status.go
+++ b/provider/data_source_incident_sub_status.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentSubStatus() *schema.Resource {

--- a/provider/data_source_incident_type.go
+++ b/provider/data_source_incident_type.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentType() *schema.Resource {

--- a/provider/data_source_incident_types.go
+++ b/provider/data_source_incident_types.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceIncidentTypes() *schema.Resource {

--- a/provider/data_source_ip_ranges.go
+++ b/provider/data_source_ip_ranges.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func dataSourceIpRanges() *schema.Resource {

--- a/provider/data_source_live_call_router.go
+++ b/provider/data_source_live_call_router.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceLiveCallRouter() *schema.Resource {

--- a/provider/data_source_on_call_role.go
+++ b/provider/data_source_on_call_role.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceOnCallRole() *schema.Resource {

--- a/provider/data_source_retrospective_configuration.go
+++ b/provider/data_source_retrospective_configuration.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceRetrospectiveConfiguration() *schema.Resource {

--- a/provider/data_source_retrospective_process_group.go
+++ b/provider/data_source_retrospective_process_group.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceRetrospectiveProcessGroup() *schema.Resource {

--- a/provider/data_source_retrospective_process_group_step.go
+++ b/provider/data_source_retrospective_process_group_step.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceRetrospectiveProcessGroupStep() *schema.Resource {

--- a/provider/data_source_role.go
+++ b/provider/data_source_role.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceRole() *schema.Resource {

--- a/provider/data_source_schedule.go
+++ b/provider/data_source_schedule.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceSchedule() *schema.Resource {

--- a/provider/data_source_service.go
+++ b/provider/data_source_service.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceService() *schema.Resource {

--- a/provider/data_source_services.go
+++ b/provider/data_source_services.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceServices() *schema.Resource {

--- a/provider/data_source_severities.go
+++ b/provider/data_source_severities.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceSeverities() *schema.Resource {

--- a/provider/data_source_severity.go
+++ b/provider/data_source_severity.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceSeverity() *schema.Resource {

--- a/provider/data_source_sla.go
+++ b/provider/data_source_sla.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/polling"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/polling"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceSLA() *schema.Resource {

--- a/provider/data_source_status_page.go
+++ b/provider/data_source_status_page.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceStatusPage() *schema.Resource {

--- a/provider/data_source_sub_status.go
+++ b/provider/data_source_sub_status.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceSubStatus() *schema.Resource {

--- a/provider/data_source_team.go
+++ b/provider/data_source_team.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceTeam() *schema.Resource {

--- a/provider/data_source_teams.go
+++ b/provider/data_source_teams.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceTeams() *schema.Resource {

--- a/provider/data_source_user.go
+++ b/provider/data_source_user.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceUser() *schema.Resource {

--- a/provider/data_source_webhooks_endpoint.go
+++ b/provider/data_source_webhooks_endpoint.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceWebhooksEndpoint() *schema.Resource {

--- a/provider/data_source_workflow.go
+++ b/provider/data_source_workflow.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceWorkflow() *schema.Resource {

--- a/provider/data_source_workflow_group.go
+++ b/provider/data_source_workflow_group.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceWorkflowGroup() *schema.Resource {

--- a/provider/data_source_workflow_task.go
+++ b/provider/data_source_workflow_task.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSourceWorkflowTask() *schema.Resource {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func init() {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/meta"
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/meta"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 // providerFactories are used to instantiate a provider during acceptance testing.

--- a/provider/resource_alert_field.go
+++ b/provider/resource_alert_field.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceAlertField() *schema.Resource {

--- a/provider/resource_alert_group.go
+++ b/provider/resource_alert_group.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceAlertGroup() *schema.Resource {

--- a/provider/resource_alert_route.go
+++ b/provider/resource_alert_route.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/polling"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/polling"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceAlertRoute() *schema.Resource {

--- a/provider/resource_alert_routing_rule.go
+++ b/provider/resource_alert_routing_rule.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceAlertRoutingRule() *schema.Resource {

--- a/provider/resource_alert_urgency.go
+++ b/provider/resource_alert_urgency.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceAlertUrgency() *schema.Resource {

--- a/provider/resource_alerts_source.go
+++ b/provider/resource_alerts_source.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceAlertsSource() *schema.Resource {

--- a/provider/resource_api_key.go
+++ b/provider/resource_api_key.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceApiKey() *schema.Resource {

--- a/provider/resource_authorization.go
+++ b/provider/resource_authorization.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceAuthorization() *schema.Resource {

--- a/provider/resource_catalog.go
+++ b/provider/resource_catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceCatalog() *schema.Resource {

--- a/provider/resource_catalog_checklist_template.go
+++ b/provider/resource_catalog_checklist_template.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCatalogChecklistTemplate() *schema.Resource {

--- a/provider/resource_catalog_entity.go
+++ b/provider/resource_catalog_entity.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCatalogEntity() *schema.Resource {

--- a/provider/resource_catalog_property.go
+++ b/provider/resource_catalog_property.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCatalogProperty() *schema.Resource {

--- a/provider/resource_cause.go
+++ b/provider/resource_cause.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCause() *schema.Resource {

--- a/provider/resource_communications_group.go
+++ b/provider/resource_communications_group.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 // filterPropertiesName removes the deprecated 'name' field from communication_group_conditions properties

--- a/provider/resource_communications_stage.go
+++ b/provider/resource_communications_stage.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceCommunicationsStage() *schema.Resource {

--- a/provider/resource_communications_template.go
+++ b/provider/resource_communications_template.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCommunicationsTemplate() *schema.Resource {

--- a/provider/resource_communications_type.go
+++ b/provider/resource_communications_type.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceCommunicationsType() *schema.Resource {

--- a/provider/resource_custom_field.go
+++ b/provider/resource_custom_field.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCustomField() *schema.Resource {

--- a/provider/resource_custom_field_option.go
+++ b/provider/resource_custom_field_option.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCustomFieldOption() *schema.Resource {

--- a/provider/resource_custom_form.go
+++ b/provider/resource_custom_form.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceCustomForm() *schema.Resource {

--- a/provider/resource_dashboard.go
+++ b/provider/resource_dashboard.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceDashboard() *schema.Resource {

--- a/provider/resource_dashboard_panel.go
+++ b/provider/resource_dashboard_panel.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/converter"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/converter"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceDashboardPanel() *schema.Resource {

--- a/provider/resource_edge_connector.go
+++ b/provider/resource_edge_connector.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEdgeConnector() *schema.Resource {

--- a/provider/resource_edge_connector_action.go
+++ b/provider/resource_edge_connector_action.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEdgeConnectorAction() *schema.Resource {

--- a/provider/resource_environment.go
+++ b/provider/resource_environment.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEnvironment() *schema.Resource {

--- a/provider/resource_escalation_level.go
+++ b/provider/resource_escalation_level.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEscalationLevel() *schema.Resource {

--- a/provider/resource_escalation_path.go
+++ b/provider/resource_escalation_path.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEscalationPath() *schema.Resource {

--- a/provider/resource_escalation_policy.go
+++ b/provider/resource_escalation_policy.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceEscalationPolicy() *schema.Resource {

--- a/provider/resource_escalation_policy_test.go
+++ b/provider/resource_escalation_policy_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/must"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/must"
 )
 
 func TestAccResourceEscalationPolicy(t *testing.T) {

--- a/provider/resource_form_field.go
+++ b/provider/resource_form_field.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormField() *schema.Resource {

--- a/provider/resource_form_field_option.go
+++ b/provider/resource_form_field_option.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormFieldOption() *schema.Resource {

--- a/provider/resource_form_field_placement.go
+++ b/provider/resource_form_field_placement.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormFieldPlacement() *schema.Resource {

--- a/provider/resource_form_field_placement_condition.go
+++ b/provider/resource_form_field_placement_condition.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormFieldPlacementCondition() *schema.Resource {

--- a/provider/resource_form_field_position.go
+++ b/provider/resource_form_field_position.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceFormFieldPosition() *schema.Resource {

--- a/provider/resource_form_set.go
+++ b/provider/resource_form_set.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormSet() *schema.Resource {

--- a/provider/resource_form_set_condition.go
+++ b/provider/resource_form_set_condition.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFormSetCondition() *schema.Resource {

--- a/provider/resource_functionality.go
+++ b/provider/resource_functionality.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceFunctionality() *schema.Resource {

--- a/provider/resource_heartbeat.go
+++ b/provider/resource_heartbeat.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceHeartbeat() *schema.Resource {

--- a/provider/resource_incident_form_field_selection.go
+++ b/provider/resource_incident_form_field_selection.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceIncidentFormFieldSelection() *schema.Resource {

--- a/provider/resource_incident_permission_set.go
+++ b/provider/resource_incident_permission_set.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceIncidentPermissionSet() *schema.Resource {

--- a/provider/resource_incident_permission_set_boolean.go
+++ b/provider/resource_incident_permission_set_boolean.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceIncidentPermissionSetBoolean() *schema.Resource {

--- a/provider/resource_incident_permission_set_resource.go
+++ b/provider/resource_incident_permission_set_resource.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceIncidentPermissionSetResource() *schema.Resource {

--- a/provider/resource_incident_role.go
+++ b/provider/resource_incident_role.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceIncidentRole() *schema.Resource {

--- a/provider/resource_incident_role_task.go
+++ b/provider/resource_incident_role_task.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceIncidentRoleTask() *schema.Resource {

--- a/provider/resource_incident_sub_status.go
+++ b/provider/resource_incident_sub_status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceIncidentSubStatus() *schema.Resource {

--- a/provider/resource_incident_type.go
+++ b/provider/resource_incident_type.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceIncidentType() *schema.Resource {

--- a/provider/resource_live_call_router.go
+++ b/provider/resource_live_call_router.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceLiveCallRouter() *schema.Resource {

--- a/provider/resource_on_call_role.go
+++ b/provider/resource_on_call_role.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceOnCallRole() *schema.Resource {

--- a/provider/resource_on_call_shadow.go
+++ b/provider/resource_on_call_shadow.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceOnCallShadow() *schema.Resource {

--- a/provider/resource_override_shift.go
+++ b/provider/resource_override_shift.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
 )
 
 func resourceOverrideShift() *schema.Resource {

--- a/provider/resource_playbook.go
+++ b/provider/resource_playbook.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourcePlaybook() *schema.Resource {

--- a/provider/resource_playbook_task.go
+++ b/provider/resource_playbook_task.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourcePlaybookTask() *schema.Resource {

--- a/provider/resource_post_mortem_template.go
+++ b/provider/resource_post_mortem_template.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourcePostmortemTemplate() *schema.Resource {

--- a/provider/resource_retrospective_configuration.go
+++ b/provider/resource_retrospective_configuration.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceRetrospectiveConfiguration() *schema.Resource {

--- a/provider/resource_retrospective_process.go
+++ b/provider/resource_retrospective_process.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceRetrospectiveProcess() *schema.Resource {

--- a/provider/resource_retrospective_process_group.go
+++ b/provider/resource_retrospective_process_group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceRetrospectiveProcessGroup() *schema.Resource {

--- a/provider/resource_retrospective_process_group_step.go
+++ b/provider/resource_retrospective_process_group_step.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceRetrospectiveProcessGroupStep() *schema.Resource {

--- a/provider/resource_retrospective_step.go
+++ b/provider/resource_retrospective_step.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceRetrospectiveStep() *schema.Resource {

--- a/provider/resource_role.go
+++ b/provider/resource_role.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceRole() *schema.Resource {

--- a/provider/resource_schedule.go
+++ b/provider/resource_schedule.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/provider/stateupgrade"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/provider/stateupgrade"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceSchedule() *schema.Resource {

--- a/provider/resource_schedule_rotation.go
+++ b/provider/resource_schedule_rotation.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceScheduleRotation() *schema.Resource {

--- a/provider/resource_schedule_rotation_active_day.go
+++ b/provider/resource_schedule_rotation_active_day.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceScheduleRotationActiveDay() *schema.Resource {

--- a/provider/resource_schedule_rotation_user.go
+++ b/provider/resource_schedule_rotation_user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceScheduleRotationUser() *schema.Resource {

--- a/provider/resource_schedule_test.go
+++ b/provider/resource_schedule_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/must"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/must"
 )
 
 func TestAccResourceSchedule(t *testing.T) {

--- a/provider/resource_secret.go
+++ b/provider/resource_secret.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceSecret() *schema.Resource {

--- a/provider/resource_service.go
+++ b/provider/resource_service.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceService() *schema.Resource {

--- a/provider/resource_severity.go
+++ b/provider/resource_severity.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceSeverity() *schema.Resource {

--- a/provider/resource_sla.go
+++ b/provider/resource_sla.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceSLA() *schema.Resource {

--- a/provider/resource_status_page.go
+++ b/provider/resource_status_page.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceStatusPage() *schema.Resource {

--- a/provider/resource_status_page_template.go
+++ b/provider/resource_status_page_template.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceStatusPageTemplate() *schema.Resource {

--- a/provider/resource_sub_status.go
+++ b/provider/resource_sub_status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func resourceSubStatus() *schema.Resource {

--- a/provider/resource_team.go
+++ b/provider/resource_team.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceTeam() *schema.Resource {

--- a/provider/resource_webhooks_endpoint.go
+++ b/provider/resource_webhooks_endpoint.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWebhooksEndpoint() *schema.Resource {

--- a/provider/resource_workflow_action_item.go
+++ b/provider/resource_workflow_action_item.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowActionItem() *schema.Resource {

--- a/provider/resource_workflow_alert.go
+++ b/provider/resource_workflow_alert.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/provider/stateupgrade"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/provider/stateupgrade"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowAlert() *schema.Resource {

--- a/provider/resource_workflow_custom_field_selection.go
+++ b/provider/resource_workflow_custom_field_selection.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowCustomFieldSelection() *schema.Resource {

--- a/provider/resource_workflow_form_field_condition.go
+++ b/provider/resource_workflow_form_field_condition.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowFormFieldCondition() *schema.Resource {

--- a/provider/resource_workflow_group.go
+++ b/provider/resource_workflow_group.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowGroup() *schema.Resource {

--- a/provider/resource_workflow_incident.go
+++ b/provider/resource_workflow_incident.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowIncident() *schema.Resource {

--- a/provider/resource_workflow_post_mortem.go
+++ b/provider/resource_workflow_post_mortem.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowPostMortem() *schema.Resource {

--- a/provider/resource_workflow_pulse.go
+++ b/provider/resource_workflow_pulse.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowPulse() *schema.Resource {

--- a/provider/resource_workflow_simple.go
+++ b/provider/resource_workflow_simple.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowSimple() *schema.Resource {

--- a/provider/resource_workflow_task_add_action_item.go
+++ b/provider/resource_workflow_task_add_action_item.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddActionItem() *schema.Resource {

--- a/provider/resource_workflow_task_add_microsoft_teams_chat_tab.go
+++ b/provider/resource_workflow_task_add_microsoft_teams_chat_tab.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddMicrosoftTeamsChatTab() *schema.Resource {

--- a/provider/resource_workflow_task_add_microsoft_teams_tab.go
+++ b/provider/resource_workflow_task_add_microsoft_teams_tab.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddMicrosoftTeamsTab() *schema.Resource {

--- a/provider/resource_workflow_task_add_role.go
+++ b/provider/resource_workflow_task_add_role.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddRole() *schema.Resource {

--- a/provider/resource_workflow_task_add_slack_bookmark.go
+++ b/provider/resource_workflow_task_add_slack_bookmark.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddSlackBookmark() *schema.Resource {

--- a/provider/resource_workflow_task_add_team.go
+++ b/provider/resource_workflow_task_add_team.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddTeam() *schema.Resource {

--- a/provider/resource_workflow_task_add_to_timeline.go
+++ b/provider/resource_workflow_task_add_to_timeline.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAddToTimeline() *schema.Resource {

--- a/provider/resource_workflow_task_archive_microsoft_teams_channels.go
+++ b/provider/resource_workflow_task_archive_microsoft_teams_channels.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskArchiveMicrosoftTeamsChannels() *schema.Resource {

--- a/provider/resource_workflow_task_archive_slack_channels.go
+++ b/provider/resource_workflow_task_archive_slack_channels.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskArchiveSlackChannels() *schema.Resource {

--- a/provider/resource_workflow_task_attach_datadog_dashboards.go
+++ b/provider/resource_workflow_task_attach_datadog_dashboards.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAttachDatadogDashboards() *schema.Resource {

--- a/provider/resource_workflow_task_auto_assign_role_opsgenie.go
+++ b/provider/resource_workflow_task_auto_assign_role_opsgenie.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAutoAssignRoleOpsgenie() *schema.Resource {

--- a/provider/resource_workflow_task_auto_assign_role_pagerduty.go
+++ b/provider/resource_workflow_task_auto_assign_role_pagerduty.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAutoAssignRolePagerduty() *schema.Resource {

--- a/provider/resource_workflow_task_auto_assign_role_rootly.go
+++ b/provider/resource_workflow_task_auto_assign_role_rootly.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAutoAssignRoleRootly() *schema.Resource {

--- a/provider/resource_workflow_task_auto_assign_role_victor_ops.go
+++ b/provider/resource_workflow_task_auto_assign_role_victor_ops.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskAutoAssignRoleVictorOps() *schema.Resource {

--- a/provider/resource_workflow_task_call_people.go
+++ b/provider/resource_workflow_task_call_people.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCallPeople() *schema.Resource {

--- a/provider/resource_workflow_task_change_slack_channel_privacy.go
+++ b/provider/resource_workflow_task_change_slack_channel_privacy.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskChangeSlackChannelPrivacy() *schema.Resource {

--- a/provider/resource_workflow_task_create_airtable_table_record.go
+++ b/provider/resource_workflow_task_create_airtable_table_record.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateAirtableTableRecord() *schema.Resource {

--- a/provider/resource_workflow_task_create_anthropic_chat_completion.go
+++ b/provider/resource_workflow_task_create_anthropic_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateAnthropicChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_create_asana_subtask.go
+++ b/provider/resource_workflow_task_create_asana_subtask.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateAsanaSubtask() *schema.Resource {

--- a/provider/resource_workflow_task_create_asana_task.go
+++ b/provider/resource_workflow_task_create_asana_task.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateAsanaTask() *schema.Resource {

--- a/provider/resource_workflow_task_create_clickup_task.go
+++ b/provider/resource_workflow_task_create_clickup_task.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateClickupTask() *schema.Resource {

--- a/provider/resource_workflow_task_create_coda_page.go
+++ b/provider/resource_workflow_task_create_coda_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateCodaPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_confluence_page.go
+++ b/provider/resource_workflow_task_create_confluence_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateConfluencePage() *schema.Resource {

--- a/provider/resource_workflow_task_create_datadog_notebook.go
+++ b/provider/resource_workflow_task_create_datadog_notebook.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateDatadogNotebook() *schema.Resource {

--- a/provider/resource_workflow_task_create_dropbox_paper_page.go
+++ b/provider/resource_workflow_task_create_dropbox_paper_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateDropboxPaperPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_github_issue.go
+++ b/provider/resource_workflow_task_create_github_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGithubIssue() *schema.Resource {

--- a/provider/resource_workflow_task_create_gitlab_issue.go
+++ b/provider/resource_workflow_task_create_gitlab_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGitlabIssue() *schema.Resource {

--- a/provider/resource_workflow_task_create_go_to_meeting.go
+++ b/provider/resource_workflow_task_create_go_to_meeting.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoToMeeting() *schema.Resource {

--- a/provider/resource_workflow_task_create_google_calendar_event.go
+++ b/provider/resource_workflow_task_create_google_calendar_event.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoogleCalendarEvent() *schema.Resource {

--- a/provider/resource_workflow_task_create_google_docs_page.go
+++ b/provider/resource_workflow_task_create_google_docs_page.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoogleDocsPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_google_docs_permissions.go
+++ b/provider/resource_workflow_task_create_google_docs_permissions.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoogleDocsPermissions() *schema.Resource {

--- a/provider/resource_workflow_task_create_google_gemini_chat_completion.go
+++ b/provider/resource_workflow_task_create_google_gemini_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoogleGeminiChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_create_google_meeting.go
+++ b/provider/resource_workflow_task_create_google_meeting.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateGoogleMeeting() *schema.Resource {

--- a/provider/resource_workflow_task_create_incident.go
+++ b/provider/resource_workflow_task_create_incident.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateIncident() *schema.Resource {

--- a/provider/resource_workflow_task_create_incident_postmortem.go
+++ b/provider/resource_workflow_task_create_incident_postmortem.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateIncidentPostmortem() *schema.Resource {

--- a/provider/resource_workflow_task_create_jira_issue.go
+++ b/provider/resource_workflow_task_create_jira_issue.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateJiraIssue() *schema.Resource {

--- a/provider/resource_workflow_task_create_jira_subtask.go
+++ b/provider/resource_workflow_task_create_jira_subtask.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateJiraSubtask() *schema.Resource {

--- a/provider/resource_workflow_task_create_jsmops_alert.go
+++ b/provider/resource_workflow_task_create_jsmops_alert.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateJsmopsAlert() *schema.Resource {

--- a/provider/resource_workflow_task_create_linear_issue.go
+++ b/provider/resource_workflow_task_create_linear_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateLinearIssue() *schema.Resource {

--- a/provider/resource_workflow_task_create_linear_issue_comment.go
+++ b/provider/resource_workflow_task_create_linear_issue_comment.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateLinearIssueComment() *schema.Resource {

--- a/provider/resource_workflow_task_create_linear_subtask_issue.go
+++ b/provider/resource_workflow_task_create_linear_subtask_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateLinearSubtaskIssue() *schema.Resource {

--- a/provider/resource_workflow_task_create_microsoft_teams_channel.go
+++ b/provider/resource_workflow_task_create_microsoft_teams_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateMicrosoftTeamsChannel() *schema.Resource {

--- a/provider/resource_workflow_task_create_microsoft_teams_chat.go
+++ b/provider/resource_workflow_task_create_microsoft_teams_chat.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateMicrosoftTeamsChat() *schema.Resource {

--- a/provider/resource_workflow_task_create_microsoft_teams_meeting.go
+++ b/provider/resource_workflow_task_create_microsoft_teams_meeting.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateMicrosoftTeamsMeeting() *schema.Resource {

--- a/provider/resource_workflow_task_create_mistral_chat_completion.go
+++ b/provider/resource_workflow_task_create_mistral_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateMistralChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_create_motion_task.go
+++ b/provider/resource_workflow_task_create_motion_task.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateMotionTask() *schema.Resource {

--- a/provider/resource_workflow_task_create_notion_page.go
+++ b/provider/resource_workflow_task_create_notion_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateNotionPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_openai_chat_completion.go
+++ b/provider/resource_workflow_task_create_openai_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateOpenaiChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_create_opsgenie_alert.go
+++ b/provider/resource_workflow_task_create_opsgenie_alert.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateOpsgenieAlert() *schema.Resource {

--- a/provider/resource_workflow_task_create_outlook_event.go
+++ b/provider/resource_workflow_task_create_outlook_event.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateOutlookEvent() *schema.Resource {

--- a/provider/resource_workflow_task_create_pagerduty_status_update.go
+++ b/provider/resource_workflow_task_create_pagerduty_status_update.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreatePagerdutyStatusUpdate() *schema.Resource {

--- a/provider/resource_workflow_task_create_pagertree_alert.go
+++ b/provider/resource_workflow_task_create_pagertree_alert.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreatePagertreeAlert() *schema.Resource {

--- a/provider/resource_workflow_task_create_quip_page.go
+++ b/provider/resource_workflow_task_create_quip_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateQuipPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_service_now_incident.go
+++ b/provider/resource_workflow_task_create_service_now_incident.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateServiceNowIncident() *schema.Resource {

--- a/provider/resource_workflow_task_create_sharepoint_page.go
+++ b/provider/resource_workflow_task_create_sharepoint_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateSharepointPage() *schema.Resource {

--- a/provider/resource_workflow_task_create_shortcut_story.go
+++ b/provider/resource_workflow_task_create_shortcut_story.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateShortcutStory() *schema.Resource {

--- a/provider/resource_workflow_task_create_shortcut_task.go
+++ b/provider/resource_workflow_task_create_shortcut_task.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateShortcutTask() *schema.Resource {

--- a/provider/resource_workflow_task_create_slack_channel.go
+++ b/provider/resource_workflow_task_create_slack_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateSlackChannel() *schema.Resource {

--- a/provider/resource_workflow_task_create_sub_incident.go
+++ b/provider/resource_workflow_task_create_sub_incident.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateSubIncident() *schema.Resource {

--- a/provider/resource_workflow_task_create_trello_card.go
+++ b/provider/resource_workflow_task_create_trello_card.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateTrelloCard() *schema.Resource {

--- a/provider/resource_workflow_task_create_watsonx_chat_completion.go
+++ b/provider/resource_workflow_task_create_watsonx_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateWatsonxChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_create_webex_meeting.go
+++ b/provider/resource_workflow_task_create_webex_meeting.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateWebexMeeting() *schema.Resource {

--- a/provider/resource_workflow_task_create_zendesk_jira_link.go
+++ b/provider/resource_workflow_task_create_zendesk_jira_link.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateZendeskJiraLink() *schema.Resource {

--- a/provider/resource_workflow_task_create_zendesk_ticket.go
+++ b/provider/resource_workflow_task_create_zendesk_ticket.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateZendeskTicket() *schema.Resource {

--- a/provider/resource_workflow_task_create_zoom_meeting.go
+++ b/provider/resource_workflow_task_create_zoom_meeting.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskCreateZoomMeeting() *schema.Resource {

--- a/provider/resource_workflow_task_genius_create_anthropic_chat_completion.go
+++ b/provider/resource_workflow_task_genius_create_anthropic_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGeniusCreateAnthropicChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_genius_create_google_gemini_chat_completion.go
+++ b/provider/resource_workflow_task_genius_create_google_gemini_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGeniusCreateGoogleGeminiChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_genius_create_openai_chat_completion.go
+++ b/provider/resource_workflow_task_genius_create_openai_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGeniusCreateOpenaiChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_genius_create_watsonx_chat_completion.go
+++ b/provider/resource_workflow_task_genius_create_watsonx_chat_completion.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGeniusCreateWatsonxChatCompletion() *schema.Resource {

--- a/provider/resource_workflow_task_get_alerts.go
+++ b/provider/resource_workflow_task_get_alerts.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGetAlerts() *schema.Resource {

--- a/provider/resource_workflow_task_get_github_commits.go
+++ b/provider/resource_workflow_task_get_github_commits.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGetGithubCommits() *schema.Resource {

--- a/provider/resource_workflow_task_get_gitlab_commits.go
+++ b/provider/resource_workflow_task_get_gitlab_commits.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGetGitlabCommits() *schema.Resource {

--- a/provider/resource_workflow_task_get_pulses.go
+++ b/provider/resource_workflow_task_get_pulses.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskGetPulses() *schema.Resource {

--- a/provider/resource_workflow_task_http_client.go
+++ b/provider/resource_workflow_task_http_client.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskHttpClient() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_microsoft_teams_channel.go
+++ b/provider/resource_workflow_task_invite_to_microsoft_teams_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToMicrosoftTeamsChannel() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_slack_channel.go
+++ b/provider/resource_workflow_task_invite_to_slack_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToSlackChannel() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_slack_channel_opsgenie.go
+++ b/provider/resource_workflow_task_invite_to_slack_channel_opsgenie.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToSlackChannelOpsgenie() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_slack_channel_pagerduty.go
+++ b/provider/resource_workflow_task_invite_to_slack_channel_pagerduty.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToSlackChannelPagerduty() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_slack_channel_rootly.go
+++ b/provider/resource_workflow_task_invite_to_slack_channel_rootly.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToSlackChannelRootly() *schema.Resource {

--- a/provider/resource_workflow_task_invite_to_slack_channel_victor_ops.go
+++ b/provider/resource_workflow_task_invite_to_slack_channel_victor_ops.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskInviteToSlackChannelVictorOps() *schema.Resource {

--- a/provider/resource_workflow_task_page_jsmops_on_call_responders.go
+++ b/provider/resource_workflow_task_page_jsmops_on_call_responders.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPageJsmopsOnCallResponders() *schema.Resource {

--- a/provider/resource_workflow_task_page_opsgenie_on_call_responders.go
+++ b/provider/resource_workflow_task_page_opsgenie_on_call_responders.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPageOpsgenieOnCallResponders() *schema.Resource {

--- a/provider/resource_workflow_task_page_pagerduty_on_call_responders.go
+++ b/provider/resource_workflow_task_page_pagerduty_on_call_responders.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPagePagerdutyOnCallResponders() *schema.Resource {

--- a/provider/resource_workflow_task_page_rootly_on_call_responders.go
+++ b/provider/resource_workflow_task_page_rootly_on_call_responders.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPageRootlyOnCallResponders() *schema.Resource {

--- a/provider/resource_workflow_task_page_victor_ops_on_call_responders.go
+++ b/provider/resource_workflow_task_page_victor_ops_on_call_responders.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPageVictorOpsOnCallResponders() *schema.Resource {

--- a/provider/resource_workflow_task_print.go
+++ b/provider/resource_workflow_task_print.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPrint() *schema.Resource {

--- a/provider/resource_workflow_task_publish_incident.go
+++ b/provider/resource_workflow_task_publish_incident.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskPublishIncident() *schema.Resource {

--- a/provider/resource_workflow_task_redis_client.go
+++ b/provider/resource_workflow_task_redis_client.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskRedisClient() *schema.Resource {

--- a/provider/resource_workflow_task_remove_google_docs_permissions.go
+++ b/provider/resource_workflow_task_remove_google_docs_permissions.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskRemoveGoogleDocsPermissions() *schema.Resource {

--- a/provider/resource_workflow_task_rename_microsoft_teams_channel.go
+++ b/provider/resource_workflow_task_rename_microsoft_teams_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskRenameMicrosoftTeamsChannel() *schema.Resource {

--- a/provider/resource_workflow_task_rename_slack_channel.go
+++ b/provider/resource_workflow_task_rename_slack_channel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskRenameSlackChannel() *schema.Resource {

--- a/provider/resource_workflow_task_run_command_heroku.go
+++ b/provider/resource_workflow_task_run_command_heroku.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskRunCommandHeroku() *schema.Resource {

--- a/provider/resource_workflow_task_send_dashboard_report.go
+++ b/provider/resource_workflow_task_send_dashboard_report.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendDashboardReport() *schema.Resource {

--- a/provider/resource_workflow_task_send_email.go
+++ b/provider/resource_workflow_task_send_email.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendEmail() *schema.Resource {

--- a/provider/resource_workflow_task_send_microsoft_teams_blocks.go
+++ b/provider/resource_workflow_task_send_microsoft_teams_blocks.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendMicrosoftTeamsBlocks() *schema.Resource {

--- a/provider/resource_workflow_task_send_microsoft_teams_chat_message.go
+++ b/provider/resource_workflow_task_send_microsoft_teams_chat_message.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendMicrosoftTeamsChatMessage() *schema.Resource {

--- a/provider/resource_workflow_task_send_microsoft_teams_message.go
+++ b/provider/resource_workflow_task_send_microsoft_teams_message.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendMicrosoftTeamsMessage() *schema.Resource {

--- a/provider/resource_workflow_task_send_slack_blocks.go
+++ b/provider/resource_workflow_task_send_slack_blocks.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendSlackBlocks() *schema.Resource {

--- a/provider/resource_workflow_task_send_slack_message.go
+++ b/provider/resource_workflow_task_send_slack_message.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendSlackMessage() *schema.Resource {

--- a/provider/resource_workflow_task_send_sms.go
+++ b/provider/resource_workflow_task_send_sms.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendSms() *schema.Resource {

--- a/provider/resource_workflow_task_send_whatsapp_message.go
+++ b/provider/resource_workflow_task_send_whatsapp_message.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSendWhatsappMessage() *schema.Resource {

--- a/provider/resource_workflow_task_snapshot_datadog_graph.go
+++ b/provider/resource_workflow_task_snapshot_datadog_graph.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSnapshotDatadogGraph() *schema.Resource {

--- a/provider/resource_workflow_task_snapshot_grafana_dashboard.go
+++ b/provider/resource_workflow_task_snapshot_grafana_dashboard.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSnapshotGrafanaDashboard() *schema.Resource {

--- a/provider/resource_workflow_task_snapshot_looker_look.go
+++ b/provider/resource_workflow_task_snapshot_looker_look.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSnapshotLookerLook() *schema.Resource {

--- a/provider/resource_workflow_task_snapshot_new_relic_graph.go
+++ b/provider/resource_workflow_task_snapshot_new_relic_graph.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskSnapshotNewRelicGraph() *schema.Resource {

--- a/provider/resource_workflow_task_trigger_workflow.go
+++ b/provider/resource_workflow_task_trigger_workflow.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskTriggerWorkflow() *schema.Resource {

--- a/provider/resource_workflow_task_tweet_twitter_message.go
+++ b/provider/resource_workflow_task_tweet_twitter_message.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskTweetTwitterMessage() *schema.Resource {

--- a/provider/resource_workflow_task_update_action_item.go
+++ b/provider/resource_workflow_task_update_action_item.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateActionItem() *schema.Resource {

--- a/provider/resource_workflow_task_update_airtable_table_record.go
+++ b/provider/resource_workflow_task_update_airtable_table_record.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateAirtableTableRecord() *schema.Resource {

--- a/provider/resource_workflow_task_update_asana_task.go
+++ b/provider/resource_workflow_task_update_asana_task.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateAsanaTask() *schema.Resource {

--- a/provider/resource_workflow_task_update_attached_alerts.go
+++ b/provider/resource_workflow_task_update_attached_alerts.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateAttachedAlerts() *schema.Resource {

--- a/provider/resource_workflow_task_update_clickup_task.go
+++ b/provider/resource_workflow_task_update_clickup_task.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateClickupTask() *schema.Resource {

--- a/provider/resource_workflow_task_update_coda_page.go
+++ b/provider/resource_workflow_task_update_coda_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateCodaPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_confluence_page.go
+++ b/provider/resource_workflow_task_update_confluence_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateConfluencePage() *schema.Resource {

--- a/provider/resource_workflow_task_update_datadog_notebook.go
+++ b/provider/resource_workflow_task_update_datadog_notebook.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateDatadogNotebook() *schema.Resource {

--- a/provider/resource_workflow_task_update_dropbox_paper_page.go
+++ b/provider/resource_workflow_task_update_dropbox_paper_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateDropboxPaperPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_github_issue.go
+++ b/provider/resource_workflow_task_update_github_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateGithubIssue() *schema.Resource {

--- a/provider/resource_workflow_task_update_gitlab_issue.go
+++ b/provider/resource_workflow_task_update_gitlab_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateGitlabIssue() *schema.Resource {

--- a/provider/resource_workflow_task_update_google_calendar_event.go
+++ b/provider/resource_workflow_task_update_google_calendar_event.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateGoogleCalendarEvent() *schema.Resource {

--- a/provider/resource_workflow_task_update_google_docs_page.go
+++ b/provider/resource_workflow_task_update_google_docs_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateGoogleDocsPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_incident.go
+++ b/provider/resource_workflow_task_update_incident.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateIncident() *schema.Resource {

--- a/provider/resource_workflow_task_update_incident_postmortem.go
+++ b/provider/resource_workflow_task_update_incident_postmortem.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateIncidentPostmortem() *schema.Resource {

--- a/provider/resource_workflow_task_update_incident_status_timestamp.go
+++ b/provider/resource_workflow_task_update_incident_status_timestamp.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateIncidentStatusTimestamp() *schema.Resource {

--- a/provider/resource_workflow_task_update_jira_issue.go
+++ b/provider/resource_workflow_task_update_jira_issue.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateJiraIssue() *schema.Resource {

--- a/provider/resource_workflow_task_update_linear_issue.go
+++ b/provider/resource_workflow_task_update_linear_issue.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateLinearIssue() *schema.Resource {

--- a/provider/resource_workflow_task_update_motion_task.go
+++ b/provider/resource_workflow_task_update_motion_task.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateMotionTask() *schema.Resource {

--- a/provider/resource_workflow_task_update_notion_page.go
+++ b/provider/resource_workflow_task_update_notion_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateNotionPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_opsgenie_alert.go
+++ b/provider/resource_workflow_task_update_opsgenie_alert.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateOpsgenieAlert() *schema.Resource {

--- a/provider/resource_workflow_task_update_opsgenie_incident.go
+++ b/provider/resource_workflow_task_update_opsgenie_incident.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateOpsgenieIncident() *schema.Resource {

--- a/provider/resource_workflow_task_update_pagerduty_incident.go
+++ b/provider/resource_workflow_task_update_pagerduty_incident.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdatePagerdutyIncident() *schema.Resource {

--- a/provider/resource_workflow_task_update_pagertree_alert.go
+++ b/provider/resource_workflow_task_update_pagertree_alert.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdatePagertreeAlert() *schema.Resource {

--- a/provider/resource_workflow_task_update_quip_page.go
+++ b/provider/resource_workflow_task_update_quip_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateQuipPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_service_now_incident.go
+++ b/provider/resource_workflow_task_update_service_now_incident.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateServiceNowIncident() *schema.Resource {

--- a/provider/resource_workflow_task_update_sharepoint_page.go
+++ b/provider/resource_workflow_task_update_sharepoint_page.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateSharepointPage() *schema.Resource {

--- a/provider/resource_workflow_task_update_shortcut_story.go
+++ b/provider/resource_workflow_task_update_shortcut_story.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateShortcutStory() *schema.Resource {

--- a/provider/resource_workflow_task_update_shortcut_task.go
+++ b/provider/resource_workflow_task_update_shortcut_task.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateShortcutTask() *schema.Resource {

--- a/provider/resource_workflow_task_update_slack_channel_topic.go
+++ b/provider/resource_workflow_task_update_slack_channel_topic.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateSlackChannelTopic() *schema.Resource {

--- a/provider/resource_workflow_task_update_status.go
+++ b/provider/resource_workflow_task_update_status.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateStatus() *schema.Resource {

--- a/provider/resource_workflow_task_update_trello_card.go
+++ b/provider/resource_workflow_task_update_trello_card.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateTrelloCard() *schema.Resource {

--- a/provider/resource_workflow_task_update_victor_ops_incident.go
+++ b/provider/resource_workflow_task_update_victor_ops_incident.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateVictorOpsIncident() *schema.Resource {

--- a/provider/resource_workflow_task_update_zendesk_ticket.go
+++ b/provider/resource_workflow_task_update_zendesk_ticket.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTaskUpdateZendeskTicket() *schema.Resource {

--- a/provider/validation.go
+++ b/provider/validation.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func validCSSHexColor() schema.SchemaValidateFunc {

--- a/provider/validation_test.go
+++ b/provider/validation_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func TestValidPermissionAction(t *testing.T) {

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -21,7 +21,7 @@ Migrates from deprecated `rootly_alert_routing_rule` resources to the new `rootl
 
 The script follows this command pattern:
 ```bash
-go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master [FLAGS] <migration_type> > output_file.tf
+go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master [FLAGS] <migration_type> > output_file.tf
 ```
 
 ### Basic Usage with Import Commands
@@ -31,21 +31,21 @@ go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master
 export ROOTLY_API_TOKEN="your-api-token"
 
 # Generate migration file with shell import commands
-go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
+go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
 ```
 
 ### Using Import Blocks (Terraform 1.5+)
 
 ```bash
 # Generate migration file with Terraform import blocks
-go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master -import=block alert_routing_rules_to_alert_routes > alert_routes.tf
+go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master -import=block alert_routing_rules_to_alert_routes > alert_routes.tf
 ```
 
 ### With Custom API Configuration
 
 ```bash
 # Override default API settings
-go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master -api-host=https://api.rootly.com -api-token=your-token alert_routing_rules_to_alert_routes > alert_routes.tf
+go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master -api-host=https://api.rootly.com -api-token=your-token alert_routing_rules_to_alert_routes > alert_routes.tf
 ```
 
 ## Command Line Options
@@ -75,7 +75,7 @@ Set your API token and run the migration script:
 
 ```bash
 export ROOTLY_API_TOKEN="your-api-token"
-go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
+go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
 ```
 
 ### Step 2: Review Generated Configuration

--- a/scripts/migration/cli.go
+++ b/scripts/migration/cli.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration/migrators"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration/migrators"
 )
 
 const (
@@ -102,7 +102,7 @@ func (cli *CLI) parseInputArguments() (*migrators.Config, error) {
     and import statements to bring them under Terraform management.
 
 USAGE:
-    go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master [FLAGS] <migration_type>
+    go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master [FLAGS] <migration_type>
 
 MIGRATION TYPES:
     alert_routing_rules_to_alert_routes
@@ -126,17 +126,17 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
     # Basic usage with import commands
-    go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
+    go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
 
     # Generate import blocks instead of shell commands
-    go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master -import=block alert_routing_rules_to_alert_routes > alert_routes.tf
+    go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master -import=block alert_routing_rules_to_alert_routes > alert_routes.tf
 
     # With explicit API configuration
-    go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master -api-host=https://api.rootly.com -api-token=your-token alert_routing_rules_to_alert_routes > alert_routes.tf
+    go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master -api-host=https://api.rootly.com -api-token=your-token alert_routing_rules_to_alert_routes > alert_routes.tf
 
     # Set environment variables first
     export ROOTLY_API_TOKEN="your-api-token"
-    go run github.com/rootlyhq/terraform-provider-rootly/v2/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
+    go run github.com/rootlyhq/terraform-provider-rootly/v5/scripts/migration@master alert_routing_rules_to_alert_routes > alert_routes.tf
 
 WORKFLOW:
     1. Run the migration script to generate Terraform configuration

--- a/tools/generate-client-tpl.js
+++ b/tools/generate-client-tpl.js
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"fmt"
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ${nameCamel} struct {

--- a/tools/generate-data-source-tpl.js
+++ b/tools/generate-data-source-tpl.js
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 func dataSource${nameCamel}() *schema.Resource {

--- a/tools/generate-provider-tpl.js
+++ b/tools/generate-provider-tpl.js
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 	goversion "github.com/hashicorp/go-version"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
 )
 
 func init() {

--- a/tools/generate-read-only-client-tpl.js
+++ b/tools/generate-read-only-client-tpl.js
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"fmt"
 	"github.com/google/jsonapi"
-	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v2/schema"
+	rootlygo "github.com/rootlyhq/terraform-provider-rootly/v5/schema"
 )
 
 type ${nameCamel} struct {

--- a/tools/generate-resource-tpl.js
+++ b/tools/generate-resource-tpl.js
@@ -28,10 +28,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/converter"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/internal/diffsuppressfunc"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/converter"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/internal/diffsuppressfunc"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resource${nameCamel}() *schema.Resource {

--- a/tools/generate-tasks.js
+++ b/tools/generate-tasks.js
@@ -30,8 +30,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resourceWorkflowTask${task_name_camel}() *schema.Resource {

--- a/tools/generate-workflow-tpl.js
+++ b/tools/generate-workflow-tpl.js
@@ -24,8 +24,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/client"
-	"github.com/rootlyhq/terraform-provider-rootly/v2/tools"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
 func resource${nameCamel}() *schema.Resource {


### PR DESCRIPTION
## Description

<!--- What changes are being made in this PR? --->

## Motivation

<!--- Why are we making this change? What problem does it solve? Link any related issues. --->
As we've released a few major version bumps since v2, we should align
the Semantic Module Import path to correspond with this, i.e. so
`pkg.go.dev` picks up this v5 version.


## Testing

- [ ] Added new tests for this functionality
- [ ] Existing tests cover this change
- [x] No tests needed (explain why below)

## Risk Assessment

- [ ] Added risk level label (low/medium/high risk)
