### PR TITLE
Add stale issues and PRs workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: "Close stale issues and PR"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f #v10.2.0
+        with:
+          stale-issue-message: "This issue is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 2 days."
+          stale-pr-message: "This PR is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 2 days."
+          close-issue-message: "This issue was closed because it has been stalled for 2 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 2 days with no activity."
+          days-before-stale: 10
+          days-before-close: 2
+          exempt-issue-labels: "on hold,WIP"
+          exempt-pr-labels: "on hold,WIP"
+          ignore-updates: true


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow to automatically close stale issues and PRs. Runs daily at 1:30 AM UTC. Marks items stale after 10 days of inactivity, closes after 2 more days. Items labeled "on hold" or "WIP" are exempt.

## Motivation

Keep issue/PR backlog clean by auto-closing abandoned items, matching the pattern used in other Rootly repos.

## Testing

- [ ] No tests needed — CI workflow only, no provider code changes

## Risk Assessment

- [ ] Added risk level label (low/medium/high risk)