### PR TITLE
Add test coverage lint script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,12 @@ jobs:
       run: |
         scripts/lint-test-names.sh
 
+    - name: Check new resources have tests
+      if: github.event_name == 'pull_request'
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=1
+        scripts/lint-test-coverage.sh origin/${{ github.base_ref }}
+
   # run acceptance tests in a matrix with Terraform core versions
   test:
     name: Matrix Test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -161,6 +161,9 @@ check-docs-drift: docs
 check-docs-completeness:
 	@scripts/lint-docs-completeness.sh
 
+check-test-coverage:
+	@scripts/lint-test-coverage.sh
+
 # General help target
 help:
 	@echo "Available targets:"
@@ -178,5 +181,6 @@ help:
 	@echo "Drift Detection:"
 	@echo "  make check-docs-drift        - Check for documentation drift"
 	@echo "  make check-docs-completeness - Check docs coverage for all resources"
+	@echo "  make check-test-coverage     - Check test coverage for all resources"
 	@echo ""
 	@make help-version

--- a/scripts/lint-test-coverage.sh
+++ b/scripts/lint-test-coverage.sh
@@ -98,8 +98,8 @@ if [ "$count_untested_wf" -gt 0 ]; then
   echo ""
 fi
 
-resource_pct=$((total_tested_resources * 100 / total_resources))
-ds_pct=$((total_tested_datasources * 100 / total_datasources))
+resource_pct=$(( total_resources > 0 ? total_tested_resources * 100 / total_resources : 0 ))
+ds_pct=$(( total_datasources > 0 ? total_tested_datasources * 100 / total_datasources : 0 ))
 
 echo "📊 Summary:"
 echo "   Resources:    $total_tested_resources/$total_resources tested ($resource_pct%)"

--- a/scripts/lint-test-coverage.sh
+++ b/scripts/lint-test-coverage.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 PROVIDER_DIR="provider"
+BASE_REF="${1:-}"
+EXIT_CODE=0
 
 # Extract resource names from resource files (excluding tests)
 all_resources=$(ls "$PROVIDER_DIR"/resource_*.go 2>/dev/null \
@@ -41,6 +43,41 @@ count_untested_core=$(echo "$untested_core" | grep -c . || echo 0)
 count_untested_wf=$(echo "$untested_workflow_tasks" | grep -c . || echo 0)
 count_untested_ds=$(echo "$untested_datasources" | grep -c . || echo 0)
 
+# --- New resource gate: fail if PR adds a resource without a test ---
+if [ -n "$BASE_REF" ]; then
+  echo "Checking for new resources without tests (base: $BASE_REF)..."
+  echo ""
+
+  # Resources added in this branch that don't exist in base
+  base_resources=$(git show "$BASE_REF":provider/ 2>/dev/null \
+    | grep '^resource_' | grep -v '_test\.go$' \
+    | sed 's|resource_||;s|\.go$||' \
+    | sort -u || true)
+
+  new_resources=$(comm -23 <(echo "$all_resources") <(echo "$base_resources"))
+  new_untested=""
+
+  if [ -n "$new_resources" ]; then
+    for r in $new_resources; do
+      if ! echo "$tested_resources" | grep -qx "$r"; then
+        new_untested="${new_untested}${r}\n"
+      fi
+    done
+  fi
+
+  if [ -n "$new_untested" ]; then
+    count_new_untested=$(printf "$new_untested" | grep -c . || echo 0)
+    echo "❌ New resources added without tests ($count_new_untested):"
+    printf "$new_untested" | sed 's/^/   /'
+    echo ""
+    EXIT_CODE=1
+  else
+    echo "✅ All new resources have tests."
+    echo ""
+  fi
+fi
+
+# --- Coverage report ---
 echo "Checking test coverage..."
 echo ""
 
@@ -69,3 +106,5 @@ echo "   Resources:    $total_tested_resources/$total_resources tested ($resourc
 echo "   Data sources: $total_tested_datasources/$total_datasources tested ($ds_pct%)"
 echo "   Core resources missing: $count_untested_core"
 echo "   Workflow tasks missing: $count_untested_wf"
+
+exit $EXIT_CODE

--- a/scripts/lint-test-coverage.sh
+++ b/scripts/lint-test-coverage.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROVIDER_DIR="provider"
+
+# Extract resource names from resource files (excluding tests)
+all_resources=$(ls "$PROVIDER_DIR"/resource_*.go 2>/dev/null \
+  | grep -v '_test\.go$' \
+  | sed 's|.*/resource_||;s|\.go$||' \
+  | sort -u)
+
+# Extract resource names that have test files
+tested_resources=$(ls "$PROVIDER_DIR"/resource_*_test.go 2>/dev/null \
+  | sed 's|.*/resource_||;s|_test\.go$||' \
+  | sort -u)
+
+# Extract data source names from data source files (excluding tests)
+all_datasources=$(ls "$PROVIDER_DIR"/data_source_*.go 2>/dev/null \
+  | grep -v '_test\.go$' \
+  | sed 's|.*/data_source_||;s|\.go$||' \
+  | sort -u)
+
+# Extract data source names that have test files
+tested_datasources=$(ls "$PROVIDER_DIR"/data_source_*_test.go 2>/dev/null \
+  | sed 's|.*/data_source_||;s|_test\.go$||' \
+  | sort -u)
+
+# Find untested resources
+untested_resources=$(comm -23 <(echo "$all_resources") <(echo "$tested_resources"))
+untested_datasources=$(comm -23 <(echo "$all_datasources") <(echo "$tested_datasources"))
+
+# Split into workflow tasks vs core resources
+untested_workflow_tasks=$(echo "$untested_resources" | grep -E '^workflow_task_|^workflow_simple$' || true)
+untested_core=$(echo "$untested_resources" | grep -vE '^workflow_task_|^workflow_simple$' || true)
+
+total_resources=$(echo "$all_resources" | wc -w)
+total_datasources=$(echo "$all_datasources" | wc -w)
+total_tested_resources=$(echo "$tested_resources" | wc -w)
+total_tested_datasources=$(echo "$tested_datasources" | wc -w)
+count_untested_core=$(echo "$untested_core" | grep -c . || echo 0)
+count_untested_wf=$(echo "$untested_workflow_tasks" | grep -c . || echo 0)
+count_untested_ds=$(echo "$untested_datasources" | grep -c . || echo 0)
+
+echo "Checking test coverage..."
+echo ""
+
+if [ "$count_untested_core" -gt 0 ]; then
+  echo "⚠️  Core resources missing tests ($count_untested_core):"
+  echo "$untested_core" | sed 's/^/   /'
+  echo ""
+fi
+
+if [ "$count_untested_ds" -gt 0 ]; then
+  echo "⚠️  Data sources missing tests ($count_untested_ds):"
+  echo "$untested_datasources" | sed 's/^/   /'
+  echo ""
+fi
+
+if [ "$count_untested_wf" -gt 0 ]; then
+  echo "ℹ️  Workflow tasks missing tests ($count_untested_wf) — omitted from output"
+  echo ""
+fi
+
+resource_pct=$((total_tested_resources * 100 / total_resources))
+ds_pct=$((total_tested_datasources * 100 / total_datasources))
+
+echo "📊 Summary:"
+echo "   Resources:    $total_tested_resources/$total_resources tested ($resource_pct%)"
+echo "   Data sources: $total_tested_datasources/$total_datasources tested ($ds_pct%)"
+echo "   Core resources missing: $count_untested_core"
+echo "   Workflow tasks missing: $count_untested_wf"


### PR DESCRIPTION
## Summary

Two things:

### 1. Test coverage report (`make check-test-coverage`)
Reports which resources and data sources are missing test files.

```
📊 Summary:
   Resources:    53/221 tested (23%)
   Data sources: 6/66 tested (9%)
   Core resources missing: 29
   Workflow tasks missing: 140
```

### 2. New resource test gate (CI)
Fails the Lint job if a PR adds a new resource file without a corresponding test file. Compares against base branch to detect new resources only — existing test debt doesn't block PRs.

```yaml
# In test.yml Lint job:
- name: Check new resources have tests
  if: github.event_name == 'pull_request'
  run: |
    git fetch origin ${{ github.base_ref }} --depth=1
    scripts/lint-test-coverage.sh origin/${{ github.base_ref }}
```

### Usage
```bash
make check-test-coverage                       # report only
scripts/lint-test-coverage.sh origin/master    # gate mode (fails on new untested resources)
```

## Test plan
- [x] Report mode works locally (no base ref)
- [x] Gate mode works locally (with base ref)
- [x] No false positives on this branch (no new resources)
- [ ] CI runs gate check on PR