### PR TITLE
Add acceptance tests for 5 core resources

### DIFF
--- a/provider/resource_alert_urgency_test.go
+++ b/provider/resource_alert_urgency_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceAlertUrgency(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-urgency")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAlertUrgencyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_alert_urgency.test", "name", rName),
+					resource.TestCheckResourceAttr("rootly_alert_urgency.test", "description", "Test urgency"),
+				),
+			},
+			{
+				Config: testAccResourceAlertUrgencyConfigUpdated(rName+"-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_alert_urgency.test", "name", rName+"-updated"),
+					resource.TestCheckResourceAttr("rootly_alert_urgency.test", "description", "Updated urgency"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceAlertUrgencyConfig(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_alert_urgency" "test" {
+	name        = "%s"
+	description = "Test urgency"
+}
+`, name)
+}
+
+func testAccResourceAlertUrgencyConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_alert_urgency" "test" {
+	name        = "%s"
+	description = "Updated urgency"
+}
+`, name)
+}

--- a/provider/resource_role_test.go
+++ b/provider/resource_role_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceRole(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-role")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRoleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_role.test", "name", rName),
+				),
+			},
+			{
+				Config: testAccResourceRoleConfigUpdated(rName + "-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_role.test", "name", rName+"-updated"),
+					resource.TestCheckResourceAttr("rootly_role.test", "incidents_permissions.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceRoleConfig(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_role" "test" {
+	name = "%s"
+}
+`, name)
+}
+
+func testAccResourceRoleConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_role" "test" {
+	name = "%s"
+	incidents_permissions = ["read", "update"]
+}
+`, name)
+}

--- a/provider/resource_schedule_rotation_test.go
+++ b/provider/resource_schedule_rotation_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceScheduleRotation(t *testing.T) {
+	scheduleName := acctest.RandomWithPrefix("tf-sched")
+	rotationName := acctest.RandomWithPrefix("tf-rotation")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceScheduleRotationConfig(scheduleName, rotationName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_schedule_rotation.test", "name", rotationName),
+					resource.TestCheckResourceAttr("rootly_schedule_rotation.test", "active_all_week", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceScheduleRotationConfig(scheduleName, rotationName string) string {
+	return fmt.Sprintf(`
+resource "rootly_schedule" "test" {
+	name = "%s"
+}
+
+resource "rootly_schedule_rotation" "test" {
+	schedule_id     = rootly_schedule.test.id
+	name            = "%s"
+	active_all_week  = true
+	active_time_type = "all_day"
+	position         = 1
+	start_time       = "2025-06-20T00:00:00Z"
+	schedule_rotationable_attributes = {
+		shift_length      = 7
+		shift_length_unit = "days"
+		handoff_time      = "09:00"
+	}
+	schedule_rotationable_type = "ScheduleCustomRotation"
+	time_zone                  = "UTC"
+}
+`, scheduleName, rotationName)
+}

--- a/provider/resource_schedule_rotation_user_test.go
+++ b/provider/resource_schedule_rotation_user_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceScheduleRotationUser(t *testing.T) {
+	scheduleName := acctest.RandomWithPrefix("tf-sched")
+	rotationName := acctest.RandomWithPrefix("tf-rotation")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceScheduleRotationUserConfig(scheduleName, rotationName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("rootly_schedule_rotation_user.test", "id"),
+					resource.TestCheckResourceAttr("rootly_schedule_rotation_user.test", "position", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceScheduleRotationUserConfig(scheduleName, rotationName string) string {
+	return fmt.Sprintf(`
+data "rootly_user" "test" {
+	email = "demo@rootly.com"
+}
+
+resource "rootly_schedule" "test" {
+	name = "%s"
+}
+
+resource "rootly_schedule_rotation" "test" {
+	schedule_id     = rootly_schedule.test.id
+	name            = "%s"
+	active_all_week  = true
+	active_time_type = "all_day"
+	position         = 1
+	start_time       = "2025-06-20T00:00:00Z"
+	schedule_rotationable_attributes = {
+		shift_length      = 7
+		shift_length_unit = "days"
+		handoff_time      = "09:00"
+	}
+	schedule_rotationable_type = "ScheduleCustomRotation"
+	time_zone                  = "UTC"
+}
+
+resource "rootly_schedule_rotation_user" "test" {
+	schedule_rotation_id = rootly_schedule_rotation.test.id
+	user_id              = data.rootly_user.test.id
+	position             = 1
+}
+`, scheduleName, rotationName)
+}

--- a/provider/resource_schedule_rotation_user_test.go
+++ b/provider/resource_schedule_rotation_user_test.go
@@ -30,7 +30,7 @@ func TestAccResourceScheduleRotationUser(t *testing.T) {
 func testAccResourceScheduleRotationUserConfig(scheduleName, rotationName string) string {
 	return fmt.Sprintf(`
 data "rootly_user" "test" {
-	email = "demo@rootly.com"
+	email = "bot+tftests@rootly.com"
 }
 
 resource "rootly_schedule" "test" {

--- a/provider/resource_team_test.go
+++ b/provider/resource_team_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceTeam(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-team")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTeamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_team.test", "name", rName),
+					resource.TestCheckResourceAttr("rootly_team.test", "description", "Test team"),
+				),
+			},
+			{
+				Config: testAccResourceTeamConfigUpdated(rName + "-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rootly_team.test", "name", rName+"-updated"),
+					resource.TestCheckResourceAttr("rootly_team.test", "description", "Updated description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceTeamConfig(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_team" "test" {
+	name        = "%s"
+	description = "Test team"
+}
+`, name)
+}
+
+func testAccResourceTeamConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "rootly_team" "test" {
+	name        = "%s"
+	description = "Updated description"
+}
+`, name)
+}


### PR DESCRIPTION
## Summary

Adds acceptance tests for 5 core resources that had zero test coverage:

- `rootly_team` — create + update (name, description)
- `rootly_role` — create + update (name, incidents_permissions)
- `rootly_alert_urgency` — create + update (name, description)
- `rootly_schedule_rotation` — create with parent schedule
- `rootly_schedule_rotation_user` — create with parent rotation + user data source

All tests use `acctest.RandomWithPrefix("tf-...")` per CLAUDE.md conventions.

### Coverage
```
Before: 53/221 resources tested (23%)
After:  58/221 resources tested (26%)
Core missing: 29 → 24
```

## Test plan
- [x] `go build ./...` compiles
- [x] `go vet ./provider/` passes
- [x] `scripts/lint-test-names.sh` passes
- [ ] CI acceptance tests pass with API token