### PR TITLE
Allow Functionality as alert_route destination target_type

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -174,7 +174,7 @@ Optional:
 Optional:
 
 - `target_id` (String) The ID of the target
-- `target_type` (String) The type of the target. Value must be one of `Service`, `Group`, `EscalationPolicy`.
+- `target_type` (String) The type of the target. Value must be one of `Service`, `Group`, `Functionality`, `EscalationPolicy`.
 
 ## Import
 

--- a/provider/resource_alert_route.go
+++ b/provider/resource_alert_route.go
@@ -184,8 +184,8 @@ func resourceAlertRoute() *schema.Resource {
 										Sensitive:    false,
 										ForceNew:     false,
 										WriteOnly:    false,
-										Description:  "The type of the target. Value must be one of `Service`, `Group`, `EscalationPolicy`.",
-										ValidateFunc: validation.StringInSlice([]string{"Service", "Group", "EscalationPolicy"}, false),
+										Description:  "The type of the target. Value must be one of `Service`, `Group`, `Functionality`, `EscalationPolicy`.",
+										ValidateFunc: validation.StringInSlice([]string{"Service", "Group", "Functionality", "EscalationPolicy"}, false),
 									},
 
 									"target_id": &schema.Schema{


### PR DESCRIPTION
Linear: [OC-3577](https://linear.app/rootly/issue/OC-3577/alert-routing-apitf-support#comment-26dd2a04)

Adds `Functionality` to the `target_type` enum on `alert_route` `rules.destinations` to match the API schema.

- `provider/resource_alert_route.go` — add `Functionality` to `validation.StringInSlice` + description
- `docs/resources/alert_route.md` — keep docs in sync

`alert_route` is hand-maintained (in `tools/generate.js` exclusion list), so this drift had to be patched manually.