### PR TITLE
Add pinned label to stale bot exemptions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,6 @@ jobs:
           close-pr-message: "This PR was closed because it has been stalled for 2 days with no activity."
           days-before-stale: 10
           days-before-close: 2
-          exempt-issue-labels: "on hold,WIP"
-          exempt-pr-labels: "on hold,WIP"
+          exempt-issue-labels: "on hold,WIP,pinned"
+          exempt-pr-labels: "on hold,WIP,pinned"
           ignore-updates: true


### PR DESCRIPTION
## Description

Add `pinned` label to the stale bot's exempt labels list for both issues and PRs. Issues/PRs with the `pinned` label will no longer be auto-closed by the stale bot.

## Motivation

Legitimate feature requests and bug reports (e.g. #299) are being auto-closed by the stale bot after 12 days of inactivity. Adding a `pinned` exemption label allows maintainers to protect important issues from being staled.

## Testing

- [ ] No tests needed — CI workflow config change only

## Risk Assessment

- [ ] Added risk level label (low/medium/high risk)