### PR TITLE
TER-182: rootly_escalation_level.delay can't be set to 0

### DIFF
--- a/client/escalation_levels.go
+++ b/client/escalation_levels.go
@@ -16,7 +16,7 @@ type EscalationLevel struct {
 	EscalationPolicyPathId                      string        `jsonapi:"attr,escalation_policy_path_id,omitempty"`
 	PagingStrategyConfigurationStrategy         string        `jsonapi:"attr,paging_strategy_configuration_strategy,omitempty"`
 	PagingStrategyConfigurationScheduleStrategy string        `jsonapi:"attr,paging_strategy_configuration_schedule_strategy,omitempty"`
-	Delay                                       int           `jsonapi:"attr,delay,omitempty"`
+	Delay                                       int           `jsonapi:"attr,delay"`
 	Position                                    int           `jsonapi:"attr,position,omitempty"`
 	NotificationTargetParams                    []interface{} `jsonapi:"attr,notification_target_params,omitempty"`
 }

--- a/provider/resource_escalation_level_test.go
+++ b/provider/resource_escalation_level_test.go
@@ -20,6 +20,7 @@ func TestAccResourceEscalationLevel(t *testing.T) {
 				Config: testAccResourceEscalationLevelConfig(epName, teamName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("rootly_escalation_level.test", "position", "1"),
+					resource.TestCheckResourceAttr("rootly_escalation_level.test", "delay", "0"),
 					resource.TestCheckResourceAttr("rootly_escalation_level.test", "notification_target_params.#", "1"),
 				),
 			},
@@ -40,6 +41,7 @@ resource "rootly_escalation_policy" "test" {
 resource "rootly_escalation_level" "test" {
 	escalation_policy_id = rootly_escalation_policy.test.id
 	position             = 1
+	delay                = 0
 
 	notification_target_params {
 		id   = rootly_team.test.id

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -124,6 +124,7 @@ const excluded = {
     "workflow_task",
   ],
   clients: [
+    "escalation_level", // manual fix: delay must not use omitempty so 0 is sent
     "escalation_path", // manual fix: initial_delay must not use omitempty so 0 is sent (c74784b)
   ]
 }


### PR DESCRIPTION
## Description

TER-182

## Motivation

Fix: rootly_escalation_level.delay can't be set to 0 (permadiff)

## Testing

- [x] Added new tests for this functionality

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)
