### PR TITLE
[TER-192] Add functionality option to catalog property kind validation

### DIFF
--- a/docs/resources/catalog_property.md
+++ b/docs/resources/catalog_property.md
@@ -30,7 +30,7 @@ resource "rootly_catalog_property" "support_level" {
 
 - `catalog_id` (String)
 - `catalog_type` (String) The type of catalog the property belongs to.. Value must be one of `catalog`, `cause`, `environment`, `functionality`, `incident_type`, `service`, `team`.
-- `kind` (String) Value must be one of `text`, `reference`, `functionality`.
+- `kind` (String) Value must be one of `text`, `reference`, `boolean`, `service`, `functionality`, `environment`, `group`, `cause`, `incident_type`, `user`.
 - `kind_catalog_id` (String) Restricts values to items of specified catalog.
 - `multiple` (Boolean) Whether the attribute accepts multiple values.. Value must be one of true or false
 - `required` (Boolean) Whether the property is required.. Value must be one of true or false

--- a/docs/resources/catalog_property.md
+++ b/docs/resources/catalog_property.md
@@ -30,7 +30,7 @@ resource "rootly_catalog_property" "support_level" {
 
 - `catalog_id` (String)
 - `catalog_type` (String) The type of catalog the property belongs to.. Value must be one of `catalog`, `cause`, `environment`, `functionality`, `incident_type`, `service`, `team`.
-- `kind` (String) Value must be one of `text`, `reference`.
+- `kind` (String) Value must be one of `text`, `reference`, `functionality`.
 - `kind_catalog_id` (String) Restricts values to items of specified catalog.
 - `multiple` (Boolean) Whether the attribute accepts multiple values.. Value must be one of true or false
 - `required` (Boolean) Whether the property is required.. Value must be one of true or false

--- a/provider/resource_catalog_property.go
+++ b/provider/resource_catalog_property.go
@@ -65,8 +65,8 @@ func resourceCatalogProperty() *schema.Resource {
 				Sensitive:    false,
 				ForceNew:     false,
 				WriteOnly:    false,
-				Description:  "Value must be one of `text`, `reference`.",
-				ValidateFunc: validation.StringInSlice([]string{"text", "reference"}, false),
+				Description:  "Value must be one of `text`, `reference`, `functionality`.",
+				ValidateFunc: validation.StringInSlice([]string{"text", "reference", "functionality"}, false),
 			},
 
 			"kind_catalog_id": &schema.Schema{

--- a/provider/resource_catalog_property.go
+++ b/provider/resource_catalog_property.go
@@ -58,15 +58,29 @@ func resourceCatalogProperty() *schema.Resource {
 			},
 
 			"kind": &schema.Schema{
-				Type:         schema.TypeString,
-				Default:      "text",
-				Required:     false,
-				Optional:     true,
-				Sensitive:    false,
-				ForceNew:     false,
-				WriteOnly:    false,
-				Description:  "Value must be one of `text`, `reference`, `functionality`.",
-				ValidateFunc: validation.StringInSlice([]string{"text", "reference", "functionality"}, false),
+				Type:        schema.TypeString,
+				Default:     "text",
+				Required:    false,
+				Optional:    true,
+				Sensitive:   false,
+				ForceNew:    false,
+				WriteOnly:   false,
+				Description: "Value must be one of `text`, `reference`, `boolean`, `service`, `functionality`, `environment`, `group`, `cause`, `incident_type`, `user`.",
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"text",
+						"reference",
+						"boolean",
+						"service",
+						"functionality",
+						"environment",
+						"group",
+						"cause",
+						"incident_type",
+						"user",
+					},
+					false,
+				),
 			},
 
 			"kind_catalog_id": &schema.Schema{


### PR DESCRIPTION
## Description

Add `kind = "functionality"` support to the `rootly_catalog_property` resource.

## Motivation

Update validation so that `functionality` kind is supported.

## Testing

- [x] Existing tests cover this change

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)
