### PR TITLE
Add owner_group_ids (Owning Team) to heartbeat resource

### DIFF
--- a/client/heartbeats.go
+++ b/client/heartbeats.go
@@ -11,23 +11,24 @@ import (
 )
 
 type Heartbeat struct {
-	ID                     string `jsonapi:"primary,heartbeats"`
-	Name                   string `jsonapi:"attr,name,omitempty"`
-	Description            string `jsonapi:"attr,description,omitempty"`
-	AlertSummary           string `jsonapi:"attr,alert_summary,omitempty"`
-	AlertDescription       string `jsonapi:"attr,alert_description,omitempty"`
-	AlertUrgencyId         string `jsonapi:"attr,alert_urgency_id,omitempty"`
-	Interval               int    `jsonapi:"attr,interval,omitempty"`
-	IntervalUnit           string `jsonapi:"attr,interval_unit,omitempty"`
-	NotificationTargetId   string `jsonapi:"attr,notification_target_id,omitempty"`
-	NotificationTargetType string `jsonapi:"attr,notification_target_type,omitempty"`
-	Enabled                *bool  `jsonapi:"attr,enabled,omitempty"`
-	Status                 string `jsonapi:"attr,status,omitempty"`
-	PingUrl                string `jsonapi:"attr,ping_url,omitempty"`
-	Secret                 string `jsonapi:"attr,secret,omitempty"`
-	EmailAddress           string `jsonapi:"attr,email_address,omitempty"`
-	LastPingedAt           string `jsonapi:"attr,last_pinged_at,omitempty"`
-	ExpiresAt              string `jsonapi:"attr,expires_at,omitempty"`
+	ID                     string        `jsonapi:"primary,heartbeats"`
+	Name                   string        `jsonapi:"attr,name,omitempty"`
+	Description            string        `jsonapi:"attr,description,omitempty"`
+	AlertSummary           string        `jsonapi:"attr,alert_summary,omitempty"`
+	AlertDescription       string        `jsonapi:"attr,alert_description,omitempty"`
+	AlertUrgencyId         string        `jsonapi:"attr,alert_urgency_id,omitempty"`
+	Interval               int           `jsonapi:"attr,interval,omitempty"`
+	IntervalUnit           string        `jsonapi:"attr,interval_unit,omitempty"`
+	NotificationTargetId   string        `jsonapi:"attr,notification_target_id,omitempty"`
+	NotificationTargetType string        `jsonapi:"attr,notification_target_type,omitempty"`
+	OwnerGroupIds          []interface{} `jsonapi:"attr,owner_group_ids,omitempty"`
+	Enabled                *bool         `jsonapi:"attr,enabled,omitempty"`
+	Status                 string        `jsonapi:"attr,status,omitempty"`
+	PingUrl                string        `jsonapi:"attr,ping_url,omitempty"`
+	Secret                 string        `jsonapi:"attr,secret,omitempty"`
+	EmailAddress           string        `jsonapi:"attr,email_address,omitempty"`
+	LastPingedAt           string        `jsonapi:"attr,last_pinged_at,omitempty"`
+	ExpiresAt              string        `jsonapi:"attr,expires_at,omitempty"`
 }
 
 func (c *Client) ListHeartbeats(params *rootlygo.ListHeartbeatsParams) ([]interface{}, error) {

--- a/docs/resources/heartbeat.md
+++ b/docs/resources/heartbeat.md
@@ -45,6 +45,7 @@ resource "rootly_heartbeat" "nightly_backup" {
 - `interval_unit` (String) Value must be one of `minutes`, `hours`, `days`.
 - `last_pinged_at` (String) When the heartbeat was last pinged.
 - `notification_target_type` (String) The type of the notification target. Please contact support if you encounter issues using `Functionality` as a target type.. Value must be one of `User`, `Group`, `Service`, `EscalationPolicy`, `Functionality`.
+- `owner_group_ids` (List of String) List of team IDs that own this heartbeat
 - `ping_url` (String) URL to receive heartbeat pings.
 - `secret` (String) Secret used as bearer token when pinging heartbeat.
 - `status` (String) Value must be one of `waiting`, `active`, `expired`.

--- a/provider/resource_heartbeat.go
+++ b/provider/resource_heartbeat.go
@@ -128,6 +128,21 @@ func resourceHeartbeat() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"User", "Group", "Service", "EscalationPolicy", "Functionality"}, false),
 			},
 
+			"owner_group_ids": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				DiffSuppressFunc: tools.EqualIgnoringOrder,
+				Computed:         false,
+				Required:         false,
+				Optional:         true,
+				Sensitive:        false,
+				ForceNew:         false,
+				WriteOnly:        false,
+				Description:      "List of team IDs that own this heartbeat",
+			},
+
 			"enabled": &schema.Schema{
 				Type:      schema.TypeBool,
 				Default:   true,
@@ -242,6 +257,9 @@ func resourceHeartbeatCreate(ctx context.Context, d *schema.ResourceData, meta i
 	if value, ok := d.GetOkExists("notification_target_type"); ok {
 		s.NotificationTargetType = value.(string)
 	}
+	if value, ok := d.GetOkExists("owner_group_ids"); ok {
+		s.OwnerGroupIds = value.([]interface{})
+	}
 	if value, ok := d.GetOkExists("enabled"); ok {
 		s.Enabled = tools.Bool(value.(bool))
 	}
@@ -301,6 +319,7 @@ func resourceHeartbeatRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("interval_unit", item.IntervalUnit)
 	d.Set("notification_target_id", item.NotificationTargetId)
 	d.Set("notification_target_type", item.NotificationTargetType)
+	d.Set("owner_group_ids", item.OwnerGroupIds)
 	d.Set("enabled", item.Enabled)
 	d.Set("status", item.Status)
 	d.Set("ping_url", item.PingUrl)
@@ -345,6 +364,15 @@ func resourceHeartbeatUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	if d.HasChange("notification_target_type") {
 		s.NotificationTargetType = d.Get("notification_target_type").(string)
 	}
+
+	if d.HasChange("owner_group_ids") {
+		if value, ok := d.GetOk("owner_group_ids"); value != nil && ok {
+			s.OwnerGroupIds = value.([]interface{})
+		} else {
+			s.OwnerGroupIds = []interface{}{}
+		}
+	}
+
 	if d.HasChange("enabled") {
 		s.Enabled = tools.Bool(d.Get("enabled").(bool))
 	}

--- a/provider/resource_heartbeat_test.go
+++ b/provider/resource_heartbeat_test.go
@@ -52,22 +52,41 @@ func TestAccResourceHeartbeat(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, true),
-				Check:  checkHeartbeatEnabled(true),
+				// Create with an owning team.
+				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkHeartbeatEnabled(true),
+					resource.TestCheckResourceAttr("rootly_heartbeat.test", "owner_group_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("rootly_heartbeat.test", "owner_group_ids.0", "rootly_team.test", "id"),
+				),
 			},
 			{
-				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, false),
-				Check:  checkHeartbeatEnabled(false),
+				// Update: clear the owning team.
+				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkHeartbeatEnabled(false),
+					resource.TestCheckResourceAttr("rootly_heartbeat.test", "owner_group_ids.#", "0"),
+				),
 			},
 			{
-				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, true),
-				Check:  checkHeartbeatEnabled(true),
+				// Update: re-add the owning team.
+				Config: testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkHeartbeatEnabled(true),
+					resource.TestCheckResourceAttr("rootly_heartbeat.test", "owner_group_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("rootly_heartbeat.test", "owner_group_ids.0", "rootly_team.test", "id"),
+				),
 			},
 		},
 	})
 }
 
-func testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName string, heartbeatEnabled bool) string {
+func testAccResourceHeartbeat(heartbeatName, teamName, alertUrgencyName string, heartbeatEnabled, withOwnerTeam bool) string {
+	ownerGroupIds := "[]"
+	if withOwnerTeam {
+		ownerGroupIds = "[rootly_team.test.id]"
+	}
+
 	return fmt.Sprintf(`
 resource "rootly_team" "test" {
   name = "%s"
@@ -86,7 +105,8 @@ resource "rootly_heartbeat" "test" {
   notification_target_id = rootly_team.test.id
   notification_target_type = "Group"
   alert_urgency_id = rootly_alert_urgency.test.id
+  owner_group_ids = %s
   enabled = %t
 }
-`, teamName, alertUrgencyName, heartbeatName, heartbeatEnabled)
+`, teamName, alertUrgencyName, heartbeatName, ownerGroupIds, heartbeatEnabled)
 }


### PR DESCRIPTION
Adds the `owner_group_ids` field to the `rootly_heartbeat` resource, matching the "Owning Team" field in the UI. Takes a list of team IDs.

The field already exists in the API spec (`owner_group_ids` on `heartbeat`, `new_heartbeat`, and `update_heartbeat`); this regenerates the heartbeat client, resource, schema, and docs to expose it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)