### PR TITLE
Fix panic on non-semver TerraformVersion (Pulumi bridge)

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -362,7 +362,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		// Warning or errors can be collected in a slice type
 		var diags diag.Diagnostics
 
-		if goversion.Must(goversion.NewVersion(p.TerraformVersion)).LessThan(goversion.Must(goversion.NewVersion("1.0"))) {
+		if tfVersion, err := goversion.NewVersion(p.TerraformVersion); err == nil && tfVersion.LessThan(goversion.Must(goversion.NewVersion("1.0"))) {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unsupported Terraform Version",

--- a/tools/generate-provider-tpl.js
+++ b/tools/generate-provider-tpl.js
@@ -143,7 +143,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		// Warning or errors can be collected in a slice type
 		var diags diag.Diagnostics
 
-		if goversion.Must(goversion.NewVersion(p.TerraformVersion)).LessThan(goversion.Must(goversion.NewVersion("1.0"))) {
+		if tfVersion, err := goversion.NewVersion(p.TerraformVersion); err == nil && tfVersion.LessThan(goversion.Must(goversion.NewVersion("1.0"))) {
 		    diags = append(diags, diag.Diagnostic{
 		        Severity: diag.Error,
 		        Summary:  "Unsupported Terraform Version",


### PR DESCRIPTION
## Description

Replace `goversion.Must()` with error-checked parse in the provider configure function. Non-semver `TerraformVersion` strings (e.g. `"pulumi-terraform-bridge"`) now skip the version check instead of panicking and crashing the provider process.

## Motivation

Fixes #379. Pulumi's dynamic Terraform provider bridge sends `TerraformVersion: "pulumi-terraform-bridge"` during configure. `goversion.Must()` panics on this non-semver string, killing the provider process. Users see a cryptic EOF error instead of a useful diagnostic.

## Testing

- [ ] Added new tests for this functionality
- [ ] Existing tests cover this change
- [x] No tests needed (explain why below)

One-line change from `goversion.Must(goversion.NewVersion(...))` to `goversion.NewVersion(...)` with error check. The panic path is untestable in normal acceptance tests since Terraform always sends a valid semver version.

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)