### PR TITLE
[OC-4761] Fix timezone handling for schedule resources

### DIFF
--- a/client/schedules.go
+++ b/client/schedules.go
@@ -27,6 +27,7 @@ type Schedule struct {
 	ShiftReportDayOfWeek               string                 `jsonapi:"attr,shift_report_day_of_week,omitempty"`
 	ShiftReportTimeOfDay               string                 `jsonapi:"attr,shift_report_time_of_day,omitempty"`
 	ShiftReportTimeZone                string                 `jsonapi:"attr,shift_report_time_zone,omitempty"`
+	TimeZone                           string                 `jsonapi:"attr,time_zone,omitempty"`
 }
 
 func (c *Client) ListSchedules(params *rootlygo.ListSchedulesParams) ([]interface{}, error) {

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -130,6 +130,7 @@ resource "rootly_schedule_rotation_user" "jane" {
 - `slack_channel` (Map of String) Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 - `slack_user_group` (Map of String) Map must contain two fields, `id` and `name`. Synced slack group of the schedule
 - `sync_linear_enabled` (Boolean) Whether the schedule is synced with Linear. Value must be one of true or false
+- `time_zone` (String) A valid IANA time zone name. Only applicable when config_one_timezone_per_schedule_enabled is true for the organization.
 
 ### Read-Only
 

--- a/provider/resource_schedule.go
+++ b/provider/resource_schedule.go
@@ -154,6 +154,16 @@ func resourceSchedule() *schema.Resource {
 				Optional:    true,
 				Description: "IANA time zone used for the weekly shift summary (e.g. `Australia/Sydney`).",
 			},
+
+			"time_zone": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Required:    false,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "A valid IANA time zone name. Only applicable when config_one_timezone_per_schedule_enabled is true for the organization.",
+			},
+
 		},
 	}
 }
@@ -224,6 +234,9 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta in
 	if value, ok := d.GetOkExists("shift_report_time_zone"); ok {
 		s.ShiftReportTimeZone = value.(string)
 	}
+	if value, ok := d.GetOkExists("time_zone"); ok {
+		s.TimeZone = value.(string)
+	}
 
 	res, err := c.CreateSchedule(s)
 	if err != nil {
@@ -268,6 +281,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("shift_report_day_of_week", item.ShiftReportDayOfWeek)
 	d.Set("shift_report_time_of_day", item.ShiftReportTimeOfDay)
 	d.Set("shift_report_time_zone", item.ShiftReportTimeZone)
+	d.Set("time_zone", item.TimeZone)
 
 	return nil
 }
@@ -340,6 +354,9 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	if d.HasChange("shift_report_time_zone") {
 		s.ShiftReportTimeZone = d.Get("shift_report_time_zone").(string)
+	}
+	if d.HasChange("time_zone") {
+		s.TimeZone = d.Get("time_zone").(string)
 	}
 
 	_, err := c.UpdateSchedule(d.Id(), s)

--- a/provider/resource_schedule_rotation.go
+++ b/provider/resource_schedule_rotation.go
@@ -124,7 +124,7 @@ func resourceScheduleRotation() *schema.Resource {
 
 			"time_zone": &schema.Schema{
 				Type:        schema.TypeString,
-				Default:     "Etc/UTC",
+				Computed:    true,
 				Required:    false,
 				Optional:    true,
 				ForceNew:    false,


### PR DESCRIPTION
## Summary

Companion PR to [rootly#20930](https://github.com/rootlyhq/rootly/pull/20930) which adds timezone validation to the schedule/rotation API for orgs with `config_one_timezone_per_schedule_enabled`.

- **schedule_rotation**: Change `time_zone` from `Default: "Etc/UTC"` to `Computed: true` — the provider was always sending `time_zone=Etc/UTC` on every create/update, which would cause 422 errors for flag-ON orgs after the API change
- **schedule**: Add `time_zone` attribute (`Computed` + `Optional`) so flag-ON orgs can manage timezone at the schedule level via Terraform
- **client/schedules.go**: Add `TimeZone` field to the `Schedule` struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)