### PR TITLE
Serialize matrix test runs globally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: tests-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Serialize all test workflow runs so their acceptance-test matrices cannot
+  # overlap while sharing the same Rootly organization.
+  group: tests
+  cancel-in-progress: false
   # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),
   # we recommend testing at a regular interval not necessarily tied to code changes. This will
   # ensure you are alerted to something breaking due to an API change, even if the code did not


### PR DESCRIPTION
## Description

Serializes all test workflow runs through one repository-wide concurrency group while preserving parallel shards within each matrix run.

## Motivation

Acceptance tests share a Rootly organization, so overlapping runs from different PRs or branches can interfere with one another.

## Testing

- [ ] Added new tests for this functionality
- [ ] Existing tests cover this change
- [x] No tests needed (workflow-only change; validated with `actionlint` and `git diff --check`)

## Risk Assessment

- [x] Added risk level label (`risk:low`)
