### PR TITLE
ci: configure release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
+
+template: |
+  $CHANGES
+
+categories:
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+  - title: 🐛 Bug fixes
+    labels:
+      - bug
+  - title: 📝 Documentation updates
+    labels:
+      - documentation
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - maintenance
+  - title: 🚦 Tests
+    labels:
+      - test
+  - title: ✍ Other changes
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
+    collapse-after: 5
+  - title: 🔐 Security
+    labels:
+      - "🔐 security"
+
+exclude-labels:
+  - skip-changelog
+  - invalid
+
+autolabeler:
+  - label: documentation
+    files:
+      - "*.md"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Set up Release Drafter using the conventions from [`rootlyhq/rootly-go`](https://github.com/rootlyhq/rootly-go/blob/master/.github/release-drafter.yml).

## What changed

- adds categorized draft notes for features, bug fixes, docs, maintenance, tests, dependencies, security, and uncategorized changes
- collapses dependency updates after five entries
- excludes `skip-changelog` and `invalid` changes
- automatically labels Markdown-only changes as `documentation`
- updates the persistent `next` draft after every push to `master`
- supports manual workflow dispatch
- pins Release Drafter to the same v7.7.0 commit used by `rootly-go`

The Rootly Go OpenAPI diff steps are intentionally excluded: this repository does not contain its vendored OpenAPI/overlay inputs, so those steps are not portable here.
