### PR TITLE
ci: limit stale workflow to pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues and PR"
+name: "Close stale PRs"
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -7,19 +7,15 @@ jobs:
   stale:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          stale-issue-message: "This issue is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 2 days."
           stale-pr-message: "This PR is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 2 days."
-          close-issue-message: "This issue was closed because it has been stalled for 2 days with no activity."
           close-pr-message: "This PR was closed because it has been stalled for 2 days with no activity."
-          days-before-stale: 10
-          days-before-close: 2
-          exempt-issue-labels: "on hold,WIP,pinned"
+          days-before-pr-stale: 10
+          days-before-pr-close: 2
           exempt-pr-labels: "on hold,WIP,pinned"
           ignore-updates: true


### PR DESCRIPTION
## Description

Tightens the existing stale workflow so it manages pull requests only, matching the Rootctl policy without processing issues.

- Renames the workflow to reflect its PR-only scope.
- Removes `issues: write` permission and all issue messages/exemptions.
- Keeps issue staling and closing explicitly disabled with `-1`.
- Uses PR-specific 10-day stale and 2-day close thresholds.
- Preserves the pinned `actions/stale` SHA, Blacksmith runner, PR messages, exemptions, and creation-date behavior.

## Motivation

The existing workflow was derived from Rootctl and disabled issue handling, but it still carried issue-write permission and issue-only configuration. Removing those leftovers makes the least-privilege and PR-only intent explicit.

## Testing

- `git diff --check`
- Workflow YAML parsed successfully
- Option names and PR-only disable behavior checked against the pinned actions/stale v11 documentation

## Risk Assessment

Low. This changes only scheduled stale automation; issues remain untouched, while PR timing and exemptions remain unchanged.