### PR TITLE
chore: upgrade Go version to 1.26.6 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rootlyhq/terraform-provider-rootly/v5
 
-go 1.25.8
+go 1.26.6
 
 require (
 	github.com/buxizhizhoum/inflection v1.0.4


### PR DESCRIPTION
## Description

Upgrade Go version to 1.26.6. Go will automatically download this version when running any `go xxx` command.

## Motivation

Upgrade Go version to 1.26.6.

## Testing

- [x] Existing tests cover this change

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)
