### PR TITLE
Prevent unapproved acceptance tests from blocking other PRs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,108 @@
+name: Acceptance Tests
+
+on:
+  workflow_call:
+    secrets:
+      ROOTLY_API_TOKEN:
+        required: true
+
+jobs:
+  # Must finish before any shard starts: it deletes every tf-* resource in the org,
+  # so running it alongside the shards deletes resources they are mid-test on.
+  sweep:
+    name: Sweep dangling test resources
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Sweep
+        timeout-minutes: 5
+        env:
+          ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
+        run: go test ./internal/provider -v -tags=sweep -sweep=all -sweep-allow-failures -timeout 5m
+        continue-on-error: true
+
+  test:
+    name: Matrix Test
+    needs: sweep
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '1.13.*'
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run internal tests (shard 0 only, sequential)
+        if: matrix.shard == 0
+        timeout-minutes: 15
+        env:
+          TF_ACC: "1"
+          ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
+        run: |
+          gotestsum --format standard-verbose -- \
+            -v -cover -timeout 15m \
+            ./internal/...
+
+      - name: Discover and shard provider tests
+        id: shard
+        run: |
+          # List test functions from provider/ only, shard by modulo
+          TESTS=$(go test -list 'Test.*' ./provider/ 2>/dev/null | grep '^Test' | sort)
+          TOTAL=$(echo "$TESTS" | wc -l)
+          SHARD=${{ matrix.shard }}
+          SHARDS=4
+
+          # Select tests for this shard
+          SHARD_TESTS=$(echo "$TESTS" | awk "NR % $SHARDS == $SHARD")
+          if [ -z "$SHARD_TESTS" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build regex pattern
+          PATTERN=$(echo "$SHARD_TESTS" | paste -sd '|')
+          echo "pattern=^($PATTERN)$" >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$SHARD_TESTS" | wc -l)" >> "$GITHUB_OUTPUT"
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "Shard $SHARD: $(echo "$SHARD_TESTS" | wc -l)/$TOTAL tests"
+
+      - name: TF acceptance tests (provider/)
+        if: steps.shard.outputs.run == 'true'
+        timeout-minutes: 45
+        env:
+          TF_ACC: "1"
+          ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
+        run: |
+          gotestsum --format standard-verbose -- \
+            -v -cover -timeout 45m -parallel 4 \
+            -run '${{ steps.shard.outputs.pattern }}' \
+            ./provider/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,6 @@ on:
       - master
   workflow_dispatch:
 
-concurrency:
-  # Serialize all test workflow runs so their acceptance-test matrices cannot
-  # overlap while sharing the same Rootly organization.
-  group: tests
-  cancel-in-progress: false
-  # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),
-  # we recommend testing at a regular interval not necessarily tied to code changes. This will
-  # ensure you are alerted to something breaking due to an API change, even if the code did not
-  # change.
-  # schedule:
-  #   - cron: '0 13 * * *'
 jobs:
   # ensure the code builds...
   build:
@@ -66,128 +55,40 @@ jobs:
         git fetch origin ${{ github.base_ref }} --depth=1
         scripts/lint-test-coverage.sh origin/${{ github.base_ref }}
 
-  # Must finish before any shard starts: it deletes every tf-* resource in the org,
-  # so running it alongside the shards deletes resources they are mid-test on.
-  sweep:
-    name: Sweep dangling test resources
+  # Keep approval outside the acceptance-test concurrency group. Otherwise an
+  # unapproved PR holds the lock and prevents every other PR from reporting CI.
+  approve-acceptance-tests:
+    name: Approve acceptance tests
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
-    steps:
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-      with:
-        go-version-file: go.mod
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Sweep
-      timeout-minutes: 5
-      env:
-        ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
-      run: |
-        go test ./internal/provider -v -tags=sweep -sweep=all -sweep-allow-failures -timeout 5m
-      continue-on-error: true
-
-  # run acceptance tests in sharded matrix for speed
-  # On push to master: runs immediately (secrets available).
-  # On PRs (including forks): requires approval from engineering team
-  # via the 'acceptance-tests' environment before secrets are exposed.
-  test:
-    name: Matrix Test
-    needs: [build, sweep]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: ${{ github.event_name == 'pull_request' && 'acceptance-tests' || '' }}
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        terraform:
-          - '1.13.*'
-        shard: [0, 1, 2, 3]
+    timeout-minutes: 1
     steps:
+      - run: echo "Acceptance tests approved"
 
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
-
-    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-      with:
-        go-version-file: go.mod
-
-    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-      with:
-        terraform_version: ${{ matrix.terraform }}
-        terraform_wrapper: false
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Install gotestsum
-      run: go install gotest.tools/gotestsum@latest
-
-    - name: Run internal tests (shard 0 only, sequential)
-      if: matrix.shard == 0
-      timeout-minutes: 15
-      env:
-        TF_ACC: "1"
-        ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
-      run: |
-        gotestsum --format standard-verbose -- \
-          -v -cover -timeout 15m \
-          ./internal/...
-
-    - name: Discover and shard provider tests
-      id: shard
-      run: |
-        # List test functions from provider/ only, shard by modulo
-        TESTS=$(go test -list 'Test.*' ./provider/ 2>/dev/null | grep '^Test' | sort)
-        TOTAL=$(echo "$TESTS" | wc -l)
-        SHARD=${{ matrix.shard }}
-        SHARDS=4
-
-        # Select tests for this shard
-        SHARD_TESTS=$(echo "$TESTS" | awk "NR % $SHARDS == $SHARD")
-        if [ -z "$SHARD_TESTS" ]; then
-          echo "run=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # Build regex pattern
-        PATTERN=$(echo "$SHARD_TESTS" | paste -sd '|')
-        echo "pattern=^($PATTERN)$" >> "$GITHUB_OUTPUT"
-        echo "count=$(echo "$SHARD_TESTS" | wc -l)" >> "$GITHUB_OUTPUT"
-        echo "run=true" >> "$GITHUB_OUTPUT"
-        echo "Shard $SHARD: $(echo "$SHARD_TESTS" | wc -l)/$TOTAL tests"
-
-    - name: TF acceptance tests (provider/)
-      if: steps.shard.outputs.run == 'true'
-      timeout-minutes: 45
-      env:
-        TF_ACC: "1"
-        ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
-      run: |
-        gotestsum --format standard-verbose -- \
-          -v -cover -timeout 45m -parallel 4 \
-          -run '${{ steps.shard.outputs.pattern }}' \
-          ./provider/
+  acceptance-tests:
+    name: Serialized acceptance tests
+    needs: approve-acceptance-tests
+    uses: ./.github/workflows/acceptance-tests.yml
+    concurrency:
+      # Acquire the shared-org lock only after environment approval. The lease
+      # covers the complete reusable workflow, including sweep and all shards.
+      group: tests
+      queue: max
+    secrets:
+      ROOTLY_API_TOKEN: ${{ secrets.ROOTLY_API_TOKEN }}
 
   # Gate job for branch protection — succeeds only when all shards pass
   test-summary:
     name: "Matrix Test (1.13.*)"
-    needs: test
+    needs: acceptance-tests
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: always()
     steps:
       - name: Check shard results
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "Test shards failed: ${{ needs.test.result }}"
+          if [ "${{ needs.acceptance-tests.result }}" != "success" ]; then
+            echo "Test shards failed: ${{ needs.acceptance-tests.result }}"
             exit 1
           fi
           echo "All test shards passed."


### PR DESCRIPTION
## What changed

- move the protected-environment approval into a lightweight gate job
- run sweep and the four acceptance-test shards through a reusable workflow
- acquire the repository-wide `tests` concurrency lease only after approval
- queue approved acceptance suites with `queue: max`
- preserve the existing `Matrix Test (1.13.*)` branch-protection check name

## Why

The workflow-level concurrency lease was acquired before GitHub evaluated the `acceptance-tests` environment. A PR waiting for approval therefore held the shared `tests` lock indefinitely, leaving every later PR at “Expected — Waiting for status to be reported.”

The new shape lets each PR build, lint, and request approval independently. Once approved, the reusable-workflow caller acquires one lease covering the destructive sweep and the complete sharded matrix, so acceptance suites still cannot overlap in the shared Rootly organization.

`ROOTLY_API_TOKEN` is a repository secret, not an environment-scoped secret, so it remains available to the reusable workflow after the approval gate.

## Validation

- `git diff --check`
- `actionlint` passed after ignoring the repository’s existing Blacksmith runner labels and its current lack of support for GitHub’s `concurrency.queue` key
- confirmed against GitHub’s current reusable-workflow and concurrency syntax
