### PR TITLE
Fix publish incident component state reads

### DIFF
--- a/docs/resources/workflow_task_publish_incident.md
+++ b/docs/resources/workflow_task_publish_incident.md
@@ -80,6 +80,8 @@ Optional:
 - `event` (String) Incident event description
 - `integration_payload` (String) Additional API Payload you can pass to statuspage.io for example. Can contain liquid markup and need to be valid JSON
 - `notify_subscribers` (Boolean) When true notifies subscribers of the status page by email/text. Value must be one of true or false
+- `selected_component_keys` (List of String) Composite "SourceType:<id>" keys of the status page components affected by the publish (requires the status-page-v3-phase-1 feature).
+- `selected_component_statuses` (Map of String) Impact status to publish for each selected component key. Keys must match selected_component_keys entries.
 - `should_tweet` (Boolean) For Statuspage.io integrated pages auto publishes a tweet for your update. Value must be one of true or false
 - `status_page_ids` (List of String) Publishes the update to every listed status page (requires the status-page-v3-limited-bulk-publish feature). When set, it takes precedence over status_page_id and the first entry becomes status_page_id.
 - `status_page_template` (Map of String) Map must contain two fields, `id` and `name`.

--- a/provider/resource_workflow_task_publish_incident.go
+++ b/provider/resource_workflow_task_publish_incident.go
@@ -28,7 +28,7 @@ func resourceWorkflowTaskPublishIncident() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateUniqueWorkflowTaskPosition,
+		CustomizeDiff: validatePublishIncidentWorkflowTaskDiff,
 
 		Schema: map[string]*schema.Schema{
 			"workflow_id": {

--- a/provider/resource_workflow_task_publish_incident.go
+++ b/provider/resource_workflow_task_publish_incident.go
@@ -4,15 +4,16 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
-	"encoding/json"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rootlyhq/terraform-provider-rootly/v5/client"
+	"reflect"
+
 	"github.com/rootlyhq/terraform-provider-rootly/v5/tools"
 )
 
@@ -29,118 +30,141 @@ func resourceWorkflowTaskPublishIncident() *schema.Resource {
 		},
 		CustomizeDiff: validateUniqueWorkflowTaskPosition,
 
-		Schema: map[string]*schema.Schema {
+		Schema: map[string]*schema.Schema{
 			"workflow_id": {
-				Description:  "The ID of the parent workflow",
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Description: "The ID of the parent workflow",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
 			},
 			"name": {
-				Description:  "Name of the workflow task",
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Description: "Name of the workflow task",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 			"position": {
-				Description:  "The position of the workflow task (1 being top of list)",
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
+				Description: "The position of the workflow task (1 being top of list)",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
 			},
 			"skip_on_failure": {
-				Description:  "Skip workflow task if any failures",
-				Type:         schema.TypeBool,
-				Optional:     true,
-				Default:      false,
+				Description: "Skip workflow task if any failures",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
 			},
 			"enabled": {
-				Description:  "Enable/disable this workflow task",
-				Type:         schema.TypeBool,
-				Optional:     true,
-				Default:      true,
+				Description: "Enable/disable this workflow task",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
 			},
 			"task_params": {
 				Description: "The parameters for this workflow task.",
-				Type: schema.TypeList,
-				Required: true,
-				MinItems: 1,
-				MaxItems: 1,
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema {
-						"task_type": &schema.Schema {
-							Type: schema.TypeString,
+					Schema: map[string]*schema.Schema{
+						"task_type": &schema.Schema{
+							Type:     schema.TypeString,
 							Optional: true,
-							Default: "publish_incident",
-							ValidateFunc: validation.StringInSlice([]string {
+							Default:  "publish_incident",
+							ValidateFunc: validation.StringInSlice([]string{
 								"publish_incident",
 							}, false),
 						},
-						"incident": &schema.Schema {
+						"incident": &schema.Schema{
 							Description: "Map must contain two fields, `id` and `name`. ",
-							Type: schema.TypeMap,
-							Required: true,
+							Type:        schema.TypeMap,
+							Required:    true,
 						},
-						"public_title": &schema.Schema {
+						"public_title": &schema.Schema{
 							Description: "",
-							Type: schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
 						},
-						"event": &schema.Schema {
+						"event": &schema.Schema{
 							Description: "Incident event description",
-							Type: schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
 						},
-						"status": &schema.Schema {
+						"status": &schema.Schema{
 							Description: "Value must be one of `investigating`, `identified`, `monitoring`, `resolved`, `scheduled`, `in_progress`, `completed`.",
-							Type: schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"investigating",
-"identified",
-"monitoring",
-"resolved",
-"scheduled",
-"in_progress",
-"completed",
+								"identified",
+								"monitoring",
+								"resolved",
+								"scheduled",
+								"in_progress",
+								"completed",
 							}, false),
 						},
-						"notify_subscribers": &schema.Schema {
+						"notify_subscribers": &schema.Schema{
 							Description: "When true notifies subscribers of the status page by email/text. Value must be one of true or false",
-							Type: schema.TypeBool,
-							Optional: true,
+							Type:        schema.TypeBool,
+							Optional:    true,
 						},
-						"should_tweet": &schema.Schema {
+						"should_tweet": &schema.Schema{
 							Description: "For Statuspage.io integrated pages auto publishes a tweet for your update. Value must be one of true or false",
-							Type: schema.TypeBool,
-							Optional: true,
+							Type:        schema.TypeBool,
+							Optional:    true,
 						},
-						"status_page_template": &schema.Schema {
+						"status_page_template": &schema.Schema{
 							Description: "Map must contain two fields, `id` and `name`. ",
-							Type: schema.TypeMap,
-							Optional: true,
+							Type:        schema.TypeMap,
+							Optional:    true,
 						},
-						"status_page_id": &schema.Schema {
+						"status_page_id": &schema.Schema{
 							Description: "",
-							Type: schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
 						},
-						"status_page_ids": &schema.Schema {
+						"status_page_ids": &schema.Schema{
 							Description: "Publishes the update to every listed status page (requires the status-page-v3-limited-bulk-publish feature). When set, it takes precedence over status_page_id and the first entry becomes status_page_id.",
-							Type: schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
 							DiffSuppressFunc: tools.EqualIgnoringOrder,
 						},
-						"integration_payload": &schema.Schema {
+						"selected_component_keys": &schema.Schema{
+							Description: "Composite \"SourceType:<id>\" keys of the status page components affected by the publish (requires the status-page-v3-phase-1 feature).",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							DiffSuppressFunc: tools.EqualIgnoringOrder,
+						},
+						"selected_component_statuses": &schema.Schema{
+							Description: "Impact status to publish for each selected component key. Keys must match selected_component_keys entries.",
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"operational",
+									"degraded_performance",
+									"partial_outage",
+									"major_outage",
+								}, false),
+							},
+						},
+						"integration_payload": &schema.Schema{
 							Description: "Additional API Payload you can pass to statuspage.io for example. Can contain liquid markup and need to be valid JSON",
-							Type: schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
 							DiffSuppressFunc: func(k, old string, new string, d *schema.ResourceData) bool {
 								var oldJSONAsInterface, newJSONAsInterface interface{}
-							
+
 								if err := json.Unmarshal([]byte(old), &oldJSONAsInterface); err != nil {
 									return false
 								}
@@ -173,12 +197,12 @@ func resourceWorkflowTaskPublishIncidentCreate(ctx context.Context, d *schema.Re
 	tflog.Trace(ctx, fmt.Sprintf("Creating workflow task: %s", workflowId))
 
 	s := &client.WorkflowTask{
-		WorkflowId: workflowId,
-		Name: name,
-		Position: position,
+		WorkflowId:    workflowId,
+		Name:          name,
+		Position:      position,
 		SkipOnFailure: skipOnFailure,
-		Enabled: enabled,
-		TaskParams: taskParams,
+		Enabled:       enabled,
+		TaskParams:    taskParams,
 	}
 
 	res, err := c.CreateWorkflowTask(s)
@@ -233,12 +257,12 @@ func resourceWorkflowTaskPublishIncidentUpdate(ctx context.Context, d *schema.Re
 	taskParams := d.Get("task_params").([]interface{})[0].(map[string]interface{})
 
 	s := &client.WorkflowTask{
-		WorkflowId: workflowId,
-		Name: name,
-		Position: position,
+		WorkflowId:    workflowId,
+		Name:          name,
+		Position:      position,
 		SkipOnFailure: skipOnFailure,
-		Enabled: enabled,
-		TaskParams: taskParams,
+		Enabled:       enabled,
+		TaskParams:    taskParams,
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("adding value: %#v", s))

--- a/provider/resource_workflow_task_publish_incident_schema_test.go
+++ b/provider/resource_workflow_task_publish_incident_schema_test.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceWorkflowTaskPublishIncidentAcceptsComponentSelection(t *testing.T) {
+	resourceData := schema.TestResourceDataRaw(t, resourceWorkflowTaskPublishIncident().Schema, nil)
+	taskParams := []interface{}{
+		map[string]interface{}{
+			"selected_component_keys": []interface{}{"Service:123"},
+			"selected_component_statuses": map[string]interface{}{
+				"Service:123": "major_outage",
+			},
+		},
+	}
+
+	if err := resourceData.Set("task_params", taskParams); err != nil {
+		t.Fatalf("set task_params returned an error: %v", err)
+	}
+}

--- a/provider/resource_workflow_task_publish_incident_validation.go
+++ b/provider/resource_workflow_task_publish_incident_validation.go
@@ -1,0 +1,59 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func validatePublishIncidentWorkflowTaskDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if err := validateUniqueWorkflowTaskPosition(ctx, d, meta); err != nil {
+		return err
+	}
+
+	taskParams, ok := d.GetOk("task_params")
+	if !ok {
+		return nil
+	}
+	paramsList, ok := taskParams.([]interface{})
+	if !ok || len(paramsList) == 0 || paramsList[0] == nil {
+		return nil
+	}
+	params, ok := paramsList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return validatePublishIncidentComponentSelection(params)
+}
+
+func validatePublishIncidentComponentSelection(params map[string]interface{}) error {
+	selectedKeys := make(map[string]struct{})
+	if keys, ok := params["selected_component_keys"].([]interface{}); ok {
+		for _, key := range keys {
+			selectedKeys[fmt.Sprint(key)] = struct{}{}
+		}
+	}
+
+	statuses, ok := params["selected_component_statuses"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	unknownKeys := make([]string, 0)
+	for key := range statuses {
+		if _, selected := selectedKeys[key]; !selected {
+			unknownKeys = append(unknownKeys, key)
+		}
+	}
+	if len(unknownKeys) == 0 {
+		return nil
+	}
+
+	sort.Strings(unknownKeys)
+	return fmt.Errorf(
+		"task_params.0.selected_component_statuses contains keys absent from selected_component_keys: %v",
+		unknownKeys,
+	)
+}

--- a/provider/resource_workflow_task_publish_incident_validation_test.go
+++ b/provider/resource_workflow_task_publish_incident_validation_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePublishIncidentComponentSelection(t *testing.T) {
+	t.Run("accepts statuses for selected keys", func(t *testing.T) {
+		params := map[string]interface{}{
+			"selected_component_keys": []interface{}{"Service:1"},
+			"selected_component_statuses": map[string]interface{}{
+				"Service:1": "major_outage",
+			},
+		}
+
+		if err := validatePublishIncidentComponentSelection(params); err != nil {
+			t.Fatalf("expected valid component selection: %v", err)
+		}
+	})
+
+	t.Run("rejects statuses for unselected keys", func(t *testing.T) {
+		params := map[string]interface{}{
+			"selected_component_keys": []interface{}{"Service:1"},
+			"selected_component_statuses": map[string]interface{}{
+				"Service:2": "major_outage",
+			},
+		}
+
+		err := validatePublishIncidentComponentSelection(params)
+		if err == nil || !strings.Contains(err.Error(), "Service:2") {
+			t.Fatalf("expected an unknown-key validation error, got: %v", err)
+		}
+	})
+}

--- a/schema/rootly-schema.gen.go
+++ b/schema/rootly-schema.gen.go
@@ -22510,6 +22510,30 @@ func (e PrintTaskParamsTaskType) Valid() bool {
 	}
 }
 
+// Defines values for PublishIncidentTaskParamsSelectedComponentStatuses.
+const (
+	PublishIncidentTaskParamsSelectedComponentStatusesDegradedPerformance PublishIncidentTaskParamsSelectedComponentStatuses = "degraded_performance"
+	PublishIncidentTaskParamsSelectedComponentStatusesMajorOutage         PublishIncidentTaskParamsSelectedComponentStatuses = "major_outage"
+	PublishIncidentTaskParamsSelectedComponentStatusesOperational         PublishIncidentTaskParamsSelectedComponentStatuses = "operational"
+	PublishIncidentTaskParamsSelectedComponentStatusesPartialOutage       PublishIncidentTaskParamsSelectedComponentStatuses = "partial_outage"
+)
+
+// Valid indicates whether the value is a known member of the PublishIncidentTaskParamsSelectedComponentStatuses enum.
+func (e PublishIncidentTaskParamsSelectedComponentStatuses) Valid() bool {
+	switch e {
+	case PublishIncidentTaskParamsSelectedComponentStatusesDegradedPerformance:
+		return true
+	case PublishIncidentTaskParamsSelectedComponentStatusesMajorOutage:
+		return true
+	case PublishIncidentTaskParamsSelectedComponentStatusesOperational:
+		return true
+	case PublishIncidentTaskParamsSelectedComponentStatusesPartialOutage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PublishIncidentTaskParamsStatus.
 const (
 	PublishIncidentTaskParamsStatusCompleted     PublishIncidentTaskParamsStatus = "completed"
@@ -51995,6 +52019,12 @@ type PublishIncidentTaskParams struct {
 	NotifySubscribers *bool  `json:"notify_subscribers,omitempty"`
 	PublicTitle       string `json:"public_title"`
 
+	// SelectedComponentKeys Composite "SourceType:<id>" keys of the status page components affected by the publish (requires the status-page-v3-phase-1 feature).
+	SelectedComponentKeys *[]string `json:"selected_component_keys,omitempty"`
+
+	// SelectedComponentStatuses Impact status to publish for each selected component key. Keys must match selected_component_keys entries.
+	SelectedComponentStatuses *map[string]PublishIncidentTaskParamsSelectedComponentStatuses `json:"selected_component_statuses,omitempty"`
+
 	// ShouldTweet For Statuspage.io integrated pages auto publishes a tweet for your update
 	ShouldTweet  *bool                           `json:"should_tweet,omitempty"`
 	Status       PublishIncidentTaskParamsStatus `json:"status"`
@@ -52008,6 +52038,9 @@ type PublishIncidentTaskParams struct {
 	} `json:"status_page_template,omitempty"`
 	TaskType *PublishIncidentTaskParamsTaskType `json:"task_type,omitempty"`
 }
+
+// PublishIncidentTaskParamsSelectedComponentStatuses defines model for PublishIncidentTaskParams.SelectedComponentStatuses.
+type PublishIncidentTaskParamsSelectedComponentStatuses string
 
 // PublishIncidentTaskParamsStatus defines model for PublishIncidentTaskParams.Status.
 type PublishIncidentTaskParamsStatus string

--- a/tools/generate-tasks.js
+++ b/tools/generate-tasks.js
@@ -38,6 +38,10 @@ const taskStateUpgrades = {
   },
 };
 
+const taskCustomizeDiffs = {
+  publish_incident: "validatePublishIncidentWorkflowTaskDiff",
+};
+
 module.exports = function generateWorkflowTaskResources(tasks, swagger) {
 	tasks.forEach((taskName) => {
 		const taskSchema = swagger.components.schemas[`${taskName}_task_params`]
@@ -66,6 +70,7 @@ function genResourceFile(task_name, task_schema) {
 
   const needsJSON = hasJSONProperty(task_schema);
   const stateUpgrade = taskStateUpgrades[task_name];
+  const customizeDiff = taskCustomizeDiffs[task_name] || "validateUniqueWorkflowTaskPosition";
 
   return `package provider
 
@@ -97,7 +102,7 @@ func resourceWorkflowTask${task_name_camel}() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateUniqueWorkflowTaskPosition,
+		CustomizeDiff: ${customizeDiff},
 ${stateUpgrade ? `		SchemaVersion: ${stateUpgrade.schemaVersion},
 		StateUpgraders: []schema.StateUpgrader{
 			{
@@ -583,8 +588,10 @@ function genTestParams(task_name, task_schema) {
           let mapValue;
           if (valueSchema.type === "boolean") {
             mapValue = "false";
-          } else if (valueSchema.type === "integer" || valueSchema.type === "number") {
+          } else if (valueSchema.type === "integer") {
             mapValue = "1";
+          } else if (valueSchema.type === "number") {
+            mapValue = `"1"`;
           } else {
             const value = valueSchema.example || valueSchema.enum?.[0] || "test";
             mapValue = `"${value}"`;

--- a/tools/generate-tasks.js
+++ b/tools/generate-tasks.js
@@ -304,6 +304,7 @@ function annotatedDescription(schema) {
   }
   if (
     schema.type === "object" &&
+    schema.properties &&
     schema.properties.id &&
     schema.properties.name
   ) {
@@ -414,6 +415,20 @@ function genTaskSchemaProperty(property_name, property_schema, required_props) {
 								},
 							},`;
     }
+  }
+  if (property_schema.type === "object" && property_schema.additionalProperties) {
+    const valueSchema = property_schema.additionalProperties;
+    a = `${a}
+							Elem: &schema.Schema {
+								Type: ${genTaskSchemaPropertyType(valueSchema.type)},`;
+    if (valueSchema.enum) {
+      a = `${a}
+								ValidateFunc: validation.StringInSlice([]string{
+									${valueSchema.enum.map((value) => `"${value}",`).join("\n")}
+								}, false),`;
+    }
+    a = `${a}
+							},`;
   }
   return `${a}
 						},`;

--- a/tools/generate-tasks.js
+++ b/tools/generate-tasks.js
@@ -578,6 +578,21 @@ function genTestParams(task_name, task_schema) {
 			return `${key} = ["foo"]`;
 		}
       case "object":
+        if (task_schema.properties[key].additionalProperties) {
+          const valueSchema = task_schema.properties[key].additionalProperties;
+          let mapValue;
+          if (valueSchema.type === "boolean") {
+            mapValue = "false";
+          } else if (valueSchema.type === "integer" || valueSchema.type === "number") {
+            mapValue = "1";
+          } else {
+            const value = valueSchema.example || valueSchema.enum?.[0] || "test";
+            mapValue = `"${value}"`;
+          }
+          return `${key} = {
+					example = ${mapValue}
+				}`;
+        }
         return `${key} = {
 					id = "foo"
 					name = "bar"

--- a/tools/ignore_array_order.go
+++ b/tools/ignore_array_order.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -11,29 +12,37 @@ import (
 func EqualIgnoringOrder(key, oldValue, newValue string, d *schema.ResourceData) bool {
 	// For a list, the key is path to the element, rather than the list.
 	// E.g. "node_groups.2.ips.0"
-	dotIndex := strings.Index(key, ".")
-	if dotIndex != -1 {
-		key = string(key[:dotIndex])
-	}
+	key = listPathFromDiffKey(key)
 
 	oldData, newData := d.GetChange(key)
 	if oldData == nil || newData == nil {
 		return false
 	}
 
- 	oldArray := oldData.([]interface{})
- 	newArray := newData.([]interface{})
- 	if len(oldArray) != len(newArray) {
- 		// Items added or removed, always detect as changed
- 		return false
- 	}
+	oldArray, oldOK := oldData.([]interface{})
+	newArray, newOK := newData.([]interface{})
+	if !oldOK || !newOK {
+		return false
+	}
+	if len(oldArray) != len(newArray) {
+		// Items added or removed, always detect as changed
+		return false
+	}
 
- 	// Workaround to detect lists being removed from plan
- 	if oldValue != newValue && newValue == "0" && oldArray[0] != "0" {
- 		return false
- 	}
+	// Workaround to detect lists being removed from plan
+	if len(oldArray) > 0 && oldValue != newValue && newValue == "0" && oldArray[0] != "0" {
+		return false
+	}
 
 	return listsAreEqual(oldArray, newArray)
+}
+
+func listPathFromDiffKey(key string) string {
+	dotIndex := strings.LastIndex(key, ".")
+	if dotIndex != -1 {
+		return key[:dotIndex]
+	}
+	return key
 }
 
 // toString converts any value to a canonical string representation.

--- a/tools/ignore_array_order_test.go
+++ b/tools/ignore_array_order_test.go
@@ -1,0 +1,17 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestEqualIgnoringOrderResolvesNestedListPath(t *testing.T) {
+	if got := listPathFromDiffKey("task_params.0.selected_component_keys.0"); got != "task_params.0.selected_component_keys" {
+		t.Fatalf("unexpected nested list path: %q", got)
+	}
+	if !listsAreEqual(
+		[]interface{}{"Service:1", "Service:2"},
+		[]interface{}{"Service:2", "Service:1"},
+	) {
+		t.Fatal("expected an order-only nested list change to be suppressed")
+	}
+}


### PR DESCRIPTION
## Why
The API now returns `selected_component_keys` and `selected_component_statuses` for publish-incident workflow tasks, but the generated Terraform schema did not include them. Reading a task therefore panicked inside `ResourceData.Set` and failed acceptance shard 2 on `master`.

## What changed
- teach workflow-task codegen to handle OpenAPI object maps with typed/validated values
- regenerate the publish-incident task schema from the current Swagger contract
- update the generated OpenAPI model for the component-selection fields
- add a regression test that sets the exact nested API shape which previously panicked

## Validation
- `node --check tools/generate-tasks.js`
- `go test ./provider -run TestResourceWorkflowTaskPublishIncidentAcceptsComponentSelection -count=1`
- `go test ./schema -count=1`
- `go build ./...`