### PR TITLE
Fix Release Drafter semantic versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,22 @@
 # Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
-name-template: $NEXT_PATCH_VERSION
-tag-template: $NEXT_PATCH_VERSION
+name-template: v$RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
 
 template: |
   $CHANGES
 
 categories:
   - title: 🚀 New features and improvements
-    labels:
-      - enhancement
+    semver-increment: minor
+    when:
+      - conventional:
+          type: feat
+      - label: enhancement
   - title: 🐛 Bug fixes
-    labels:
-      - bug
+    when:
+      - conventional:
+          type: fix
+      - label: bug
   - title: 📝 Documentation updates
     labels:
       - documentation
@@ -30,6 +35,15 @@ categories:
   - title: 🔐 Security
     labels:
       - "🔐 security"
+
+  - type: version-resolver
+    semver-increment: major
+    when:
+      - conventional:
+          breaking: true
+      - label: major
+  - type: version-resolver
+    semver-increment: patch
 
 exclude-labels:
   - skip-changelog

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,9 +18,5 @@ jobs:
     steps:
       - name: Update release draft
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
-        with:
-          name: next
-          tag: next
-          version: next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- let Release Drafter use the configured name and tag templates instead of overriding them with the literal `next`
- generate `v*` release names and tags from `$RESOLVED_VERSION`
- treat conventional `feat:` PRs and `enhancement` labels as minor releases
- treat breaking changes and the `major` label as major releases
- use a patch bump as the default for all other release contents

## Why

The existing workflow always created or updated a draft named and tagged `next`. Those action inputs overrode `.github/release-drafter.yml`, so the draft never received a semantic version and publishing it would not trigger the `v*` GoReleaser workflow.

With the current unreleased changes, this configuration resolves the next release as `v5.20.0` because #448 is a conventional `feat:` PR.

## Validation

- parsed both YAML files with Ruby Psych
- `git diff --check`
- confirmed the pinned Release Drafter v7.7.0 supports `$RESOLVED_VERSION`, conventional-title conditions, and version-resolver categories
