### PR TITLE
[IR-6163] Clarify Status Pages V3 Terraform Early Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- `rootly_status_page_component` resource: manage ad-hoc and catalog-backed (Service/Functionality) status page components, including group membership and ordering via `position`. Requires the `status-page-v3-phase-1` feature flag. (#421)
-- `rootly_status_page_component_group` resource: manage status page component groups, including `collapsed_by_default` and ordering via `position`. Deleting a group also deletes the components it contains. Requires the `status-page-v3-phase-1` feature flag. (#421)
+- `rootly_status_page_component` resource: manage ad-hoc and catalog-backed (Service/Functionality) status page components, including group membership and ordering via `position`. This resource is in Early Access and is not generally available. Contact Rootly Support to request access. (#421)
+- `rootly_status_page_component_group` resource: manage status page component groups, including `collapsed_by_default` and ordering via `position`. Deleting a group also deletes the components it contains. This resource is in Early Access and is not generally available. Contact Rootly Support to request access. (#421)
 - `rootly_escalation_level` now supports cycle-based round-robin paging through `paging_strategy_configuration_repeats`, `paging_strategy_configuration_repeats_mode`, `paging_strategy_configuration_rotation_scope`, and `paging_strategy_configuration_page_users_count`. (#424)
 - `rootly_schedule` now exposes the optional, computed `time_zone` attribute for organizations using schedule-level timezone enforcement. (#422)
 - `rootly_catalog_property.kind` now accepts `functionality`. (#370)

--- a/docs/resources/status_page_component.md
+++ b/docs/resources/status_page_component.md
@@ -2,12 +2,14 @@
 page_title: "Resource rootly_status_page_component - terraform-provider-rootly"
 subcategory:
 description: |-
-    
+  Manages a Status Pages V3 component. This resource is in Early Access and is not generally available.
 ---
 
 # Resource (rootly_status_page_component)
 
+Manages a Status Pages V3 component.
 
+*Early access: This resource is not generally available. It is available only to organizations participating in the Status Pages V3 Early Access program. Contact Rootly Support to request access.*
 
 ## Example Usage
 

--- a/docs/resources/status_page_component_group.md
+++ b/docs/resources/status_page_component_group.md
@@ -2,12 +2,14 @@
 page_title: "Resource rootly_status_page_component_group - terraform-provider-rootly"
 subcategory:
 description: |-
-    
+  Manages a Status Pages V3 component group. This resource is in Early Access and is not generally available.
 ---
 
 # Resource (rootly_status_page_component_group)
 
+Manages a Status Pages V3 component group.
 
+*Early access: This resource is not generally available. It is available only to organizations participating in the Status Pages V3 Early Access program. Contact Rootly Support to request access.*
 
 ## Example Usage
 

--- a/docs/resources/workflow_task_publish_incident.md
+++ b/docs/resources/workflow_task_publish_incident.md
@@ -80,10 +80,10 @@ Optional:
 - `event` (String) Incident event description
 - `integration_payload` (String) Additional API Payload you can pass to statuspage.io for example. Can contain liquid markup and need to be valid JSON
 - `notify_subscribers` (Boolean) When true notifies subscribers of the status page by email/text. Value must be one of true or false
-- `selected_component_keys` (List of String) Composite "SourceType:<id>" keys of the status page components affected by the publish (requires the status-page-v3-phase-1 feature).
+- `selected_component_keys` (List of String) Composite "SourceType:<id>" keys of the status page components affected by the publish. This field is in Early Access and is not generally available; contact Rootly Support to request access.
 - `selected_component_statuses` (Map of String) Impact status to publish for each selected component key. Keys must match selected_component_keys entries.
 - `should_tweet` (Boolean) For Statuspage.io integrated pages auto publishes a tweet for your update. Value must be one of true or false
-- `status_page_ids` (List of String) Publishes the update to every listed status page (requires the status-page-v3-limited-bulk-publish feature). When set, it takes precedence over status_page_id and the first entry becomes status_page_id.
+- `status_page_ids` (List of String) Publishes the update to every listed status page. This field is in limited Early Access; contact Rootly Support to request access. When set, it takes precedence over status_page_id and the first entry becomes status_page_id.
 - `status_page_template` (Map of String) Map must contain two fields, `id` and `name`.
 - `task_type` (String)
 

--- a/provider/resource_workflow_task_publish_incident.go
+++ b/provider/resource_workflow_task_publish_incident.go
@@ -127,7 +127,7 @@ func resourceWorkflowTaskPublishIncident() *schema.Resource {
 							Required:    true,
 						},
 						"status_page_ids": &schema.Schema{
-							Description: "Publishes the update to every listed status page (requires the status-page-v3-limited-bulk-publish feature). When set, it takes precedence over status_page_id and the first entry becomes status_page_id.",
+							Description: "Publishes the update to every listed status page. This field is in limited Early Access; contact Rootly Support to request access. When set, it takes precedence over status_page_id and the first entry becomes status_page_id.",
 							Type:        schema.TypeList,
 							Optional:    true,
 							Elem: &schema.Schema{
@@ -136,7 +136,7 @@ func resourceWorkflowTaskPublishIncident() *schema.Resource {
 							DiffSuppressFunc: tools.EqualIgnoringOrder,
 						},
 						"selected_component_keys": &schema.Schema{
-							Description: "Composite \"SourceType:<id>\" keys of the status page components affected by the publish (requires the status-page-v3-phase-1 feature).",
+							Description: "Composite \"SourceType:<id>\" keys of the status page components affected by the publish. This field is in Early Access and is not generally available; contact Rootly Support to request access.",
 							Type:        schema.TypeList,
 							Optional:    true,
 							Elem: &schema.Schema{

--- a/templates/resources/status_page_component.md.tmpl
+++ b/templates/resources/status_page_component.md.tmpl
@@ -1,0 +1,45 @@
+---
+page_title: "{{.Type}} {{.Name}} - terraform-provider-rootly"
+subcategory:
+description: |-
+  Manages a Status Pages V3 component. This resource is in Early Access and is not generally available.
+---
+
+# {{.Type}} ({{.Name}})
+
+Manages a Status Pages V3 component.
+
+*Early access: This resource is not generally available. It is available only to organizations participating in the Status Pages V3 Early Access program. Contact Rootly Support to request access.*
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{ codefile "shell" .ExampleFile }}
+{{- end }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+{{.Name}} can be imported using the [`import` command](https://developer.hashicorp.com/terraform/cli/commands/import).
+
+```sh
+terraform import {{.Name}}.primary a816421c-6ceb-481a-87c4-585e47451f24
+```
+
+Or using an [`import` block](https://developer.hashicorp.com/terraform/language/import).
+
+```terraform
+import {
+  to = {{.Name}}.primary
+  id = "a816421c-6ceb-481a-87c4-585e47451f24"
+}
+```
+
+Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+
+HCL can be generated from the import block using the `-generate-config-out` flag.
+
+```sh
+terraform plan -generate-config-out=generated.tf
+```

--- a/templates/resources/status_page_component_group.md.tmpl
+++ b/templates/resources/status_page_component_group.md.tmpl
@@ -1,0 +1,45 @@
+---
+page_title: "{{.Type}} {{.Name}} - terraform-provider-rootly"
+subcategory:
+description: |-
+  Manages a Status Pages V3 component group. This resource is in Early Access and is not generally available.
+---
+
+# {{.Type}} ({{.Name}})
+
+Manages a Status Pages V3 component group.
+
+*Early access: This resource is not generally available. It is available only to organizations participating in the Status Pages V3 Early Access program. Contact Rootly Support to request access.*
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{ codefile "shell" .ExampleFile }}
+{{- end }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+{{.Name}} can be imported using the [`import` command](https://developer.hashicorp.com/terraform/cli/commands/import).
+
+```sh
+terraform import {{.Name}}.primary a816421c-6ceb-481a-87c4-585e47451f24
+```
+
+Or using an [`import` block](https://developer.hashicorp.com/terraform/language/import).
+
+```terraform
+import {
+  to = {{.Name}}.primary
+  id = "a816421c-6ceb-481a-87c4-585e47451f24"
+}
+```
+
+Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+
+HCL can be generated from the import block using the `-generate-config-out` flag.
+
+```sh
+terraform plan -generate-config-out=generated.tf
+```


### PR DESCRIPTION
## What changed

- Replaces internal LaunchDarkly flag names in customer-facing Terraform documentation with clear Early Access language.
- Adds durable templates for `rootly_status_page_component` and `rootly_status_page_component_group`, making it explicit that the resources are not generally available.
- Updates the generated publish-incident task schema and Registry page for `selected_component_keys`, as reported by Matthew.
- Removes the adjacent internal bulk-publish flag name from `status_page_ids`.
- Updates the v5.19.0 changelog wording.

## Why

Customers found internal feature-flag names in the Terraform Registry and changelog, which made Early Access resources appear publicly available and created uncertainty about whether they could be used.

Related: [IR-6163](https://linear.app/rootly/issue/IR-6163) and [IR-6576](https://linear.app/rootly/issue/IR-6576).

## Impact

Documentation and schema-description changes only. No Terraform resource behavior changes.

## Validation

- `make docs`
- `go test ./provider/... -run '^$'`
- `git diff --check`
- Confirmed no remaining `status-page-v3` or `feature flag` references in the provider changelog, docs, schemas, or templates

The live acceptance suite was not run because it requires a valid Rootly API test token.
