### PR TITLE
fix: add `alert_urgency_ids` to alert routes test

### DIFF
--- a/provider/resource_alert_route_test.go
+++ b/provider/resource_alert_route_test.go
@@ -84,6 +84,7 @@ func TestAccResourceAlertRoute(t *testing.T) {
                 property_field_name = "$.title"
                 property_field_type = "payload"
                 property_field_value = "error"
+                alert_urgency_ids = [rootly_alert_urgency.test.id]
               }
             }
           }


### PR DESCRIPTION
## Description

TER-228

`alert_urgency_ids` missing from alert routes response. Add a test to demonstrate the current issue. I will run the acceptance tests once the API fix has been deployed to production.

## Motivation

<!--- Why are we making this change? What problem does it solve? Link any related issues. --->

## Testing

- [x] Added new tests for this functionality

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)