### PR TITLE
fix: strip schedule_id from schedule rotation update to prevent HTTP 500

### DIFF
--- a/internal/apiclient/schedule_rotation.go
+++ b/internal/apiclient/schedule_rotation.go
@@ -11,7 +11,7 @@ import (
 
 type ScheduleRotation struct {
 	ID                             string                                         `jsonapi:"primary,schedule_rotations"`
-	ScheduleId                     string                                         `jsonapi:"attr,schedule_id"`
+	ScheduleId                     string                                         `jsonapi:"attr,schedule_id,omitempty"`
 	Name                           string                                         `jsonapi:"attr,name"`
 	Position                       int64                                          `jsonapi:"attr,position,omitempty"`
 	ScheduleRotationableType       string                                         `jsonapi:"attr,schedule_rotationable_type"`
@@ -121,6 +121,13 @@ func (c *Client) CreateScheduleRotation(ctx context.Context, req ScheduleRotatio
 }
 
 func (c *Client) UpdateScheduleRotation(ctx context.Context, req ScheduleRotation) (*ScheduleRotation, error) {
+	// schedule_id has RequiresReplace in the provider schema — it can never
+	// change on update. Sending it in the PUT body triggers a server-side 500
+	// when schedule_rotation_members is also included. Strip it before marshaling.
+	scheduleId := req.ScheduleId
+	req.ScheduleId = ""
+	defer func() { req.ScheduleId = scheduleId }()
+
 	var buf bytes.Buffer
 	if err := jsonapi.MarshalPayload(&buf, &req); err != nil {
 		return nil, err

--- a/internal/apiclient/schedule_rotation.go
+++ b/internal/apiclient/schedule_rotation.go
@@ -124,9 +124,7 @@ func (c *Client) UpdateScheduleRotation(ctx context.Context, req ScheduleRotatio
 	// schedule_id has RequiresReplace in the provider schema — it can never
 	// change on update. Sending it in the PUT body triggers a server-side 500
 	// when schedule_rotation_members is also included. Strip it before marshaling.
-	scheduleId := req.ScheduleId
 	req.ScheduleId = ""
-	defer func() { req.ScheduleId = scheduleId }()
 
 	var buf bytes.Buffer
 	if err := jsonapi.MarshalPayload(&buf, &req); err != nil {

--- a/internal/provider/resource_schedule_rotation_test.go
+++ b/internal/provider/resource_schedule_rotation_test.go
@@ -285,3 +285,87 @@ resource "rootly_schedule_rotation" "test" {
 }
 `, name, extras)
 }
+
+func TestAccResourceScheduleRotation_MemberUpdate(t *testing.T) {
+	addr := "rootly_schedule_rotation.test"
+	name := acctest.RandomWithPrefix("tf-rotation")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceScheduleRotationMemberUpdateConfig(name, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("schedule_rotation_members"), knownvalue.SetSizeExact(1)),
+				},
+			},
+			{
+				Config: testAccResourceScheduleRotationMemberUpdateConfig(name, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("schedule_rotation_members"), knownvalue.SetSizeExact(2)),
+				},
+			},
+			{
+				Config: testAccResourceScheduleRotationMemberUpdateConfig(name, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("schedule_rotation_members"), knownvalue.SetSizeExact(1)),
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceScheduleRotationMemberUpdateConfig(name string, withSecondMember bool) string {
+	secondMember := ""
+	if withSecondMember {
+		secondMember = `
+	schedule_rotation_members {
+		position    = 2
+		member_type = "Schedule"
+		member_id   = rootly_schedule.nested.id
+	}
+`
+	}
+
+	return fmt.Sprintf(`
+data "rootly_user" "test" {
+	email = "bot+tftests@rootly.com"
+}
+
+resource "rootly_schedule" "test" {
+	name          = "%[1]s"
+	owner_user_id = data.rootly_user.test.id
+}
+
+resource "rootly_schedule" "nested" {
+	name          = "%[1]s-nested"
+	owner_user_id = data.rootly_user.test.id
+}
+
+resource "rootly_schedule_rotation" "test" {
+	schedule_id          = rootly_schedule.test.id
+	name                 = "%[1]s"
+	active_all_week      = true
+	active_time_type     = "all_day"
+	position             = 1
+	start_time           = "2025-06-20T00:00:00Z"
+
+	schedule_rotationable_type       = "ScheduleCustomRotation"
+	schedule_rotationable_attributes = {
+		shift_length      = 7
+		shift_length_unit = "days"
+		handoff_time      = "09:00"
+	}
+
+	time_zone = "UTC"
+
+	schedule_rotation_members {
+		position    = 1
+		member_type = "User"
+		member_id   = data.rootly_user.test.id
+	}
+%[2]s
+}
+`, name, secondMember)
+}


### PR DESCRIPTION
## Description

Strip `schedule_id` from the PUT body in `UpdateScheduleRotation` and add `omitempty` to its jsonapi tag. `schedule_id` has `RequiresReplace` in the provider schema so it can never change on update — sending it in the PUT body triggers a server-side 500 when `schedule_rotation_members` is also included.

## Motivation

`rootly_schedule_rotation` updates fail with HTTP 500 from the Rootly API when `schedule_rotation_members` is included. The provider retries 9 times (~23 minutes exponential backoff) and then gives up, blocking the entire `terraform apply`.

Fixes #468

## Testing

- [x] Added new tests for this functionality
- [ ] Existing tests cover this change
- [ ] No tests needed (explain why below)

Added `TestAccResourceScheduleRotation_MemberUpdate` which creates a rotation with 1 member, adds a 2nd member (Schedule type), then removes it back to 1 — verifying member updates succeed without a 500.

```bash
go build ./...                                    # passes
go vet ./internal/apiclient/                      # passes
go test ./internal/provider/ -run TestAccResourceScheduleRotation_Validation -v  # passes
```

Acceptance tests requiring live API credentials (`TestAccResourceScheduleRotation_MemberUpdate`, `TestAccResourceScheduleRotation_Basic`) need `ROOTLY_KEY` to run.

## Risk Assessment

- [x] Added risk level label (low/medium/high risk)

**Low risk.** The fix only affects the update path. `schedule_id` is immutable on update by schema design (`RequiresReplace`), so stripping it from the PUT body changes no observable behavior — it only prevents the server-side 500. The create and read paths are untouched.